### PR TITLE
feat: allow running the dashboard outside the gateway host

### DIFF
--- a/telemetry_db.py
+++ b/telemetry_db.py
@@ -11,13 +11,15 @@ Duplicate events may occur if the server crashes mid-ingest before storing the
 byte offset; this is benign for visualization purposes.
 """
 
+import os
 import sqlite3
 import time
 
 import orjson
 
-# Default DB path alongside ws_server.py
-DEFAULT_DB_PATH = "/var/www/freenet-dashboard/telemetry.db"
+# Overridable to run against a scratch database in local development.
+DEFAULT_DB_PATH = os.environ.get(
+    "FREENET_DASHBOARD_DB", "/var/www/freenet-dashboard/telemetry.db")
 
 # Keep 48 hours of data by default. The telemetry firehose is ~46 GB/day, so a
 # 7-day window grew the DB past 300 GB and filled the root disk (2026-05-22).

--- a/ws_server.py
+++ b/ws_server.py
@@ -33,9 +33,12 @@ try:
 except ImportError:
     OPENAI_AVAILABLE = False
 
-TELEMETRY_LOG = Path("/mnt/media/freenet-telemetry/logs.jsonl")
-WS_PORT = 3134
-PEER_NAMES_FILE = Path("/var/www/freenet-dashboard/peer_names.json")
+# Defaults are the gateway-host layout; overridable to run against a local collector.
+TELEMETRY_LOG = Path(os.environ.get(
+    "FREENET_TELEMETRY_LOG", "/mnt/media/freenet-telemetry/logs.jsonl"))
+WS_PORT = int(os.environ.get("FREENET_DASHBOARD_WS_PORT", "3134"))
+PEER_NAMES_FILE = Path(os.environ.get(
+    "FREENET_PEER_NAMES_FILE", "/var/www/freenet-dashboard/peer_names.json"))
 
 # Connection limits - reserve slots for returning users and peers
 MAX_CLIENTS = 300           # Total max connections
@@ -834,10 +837,17 @@ def ip_hash(ip: str) -> str:
     return hashlib.sha256(ip.encode()).hexdigest()[:6]
 
 
+# Local development only: without this the filter below hides every node a
+# developer can run. In production it would let test/CI nodes into the topology.
+ALLOW_PRIVATE_IPS = os.environ.get("FREENET_DASHBOARD_ALLOW_PRIVATE_IPS") == "1"
+
+
 def is_public_ip(ip: str) -> bool:
     """Check if IP is a public (non-test) address."""
     if not ip:
         return False
+    if ALLOW_PRIVATE_IPS:
+        return ip != "localhost"
     if ip.startswith("127.") or ip.startswith("172.") or ip.startswith("10.") or ip.startswith("192.168."):
         return False
     if ip.startswith("0.") or ip == "localhost":


### PR DESCRIPTION
## Problem

The dashboard can only run on the machine it was deployed to. Four paths are hardcoded (the telemetry log, the SQLite database, the peer-names file and the WebSocket port), and `is_public_ip()` rejects `127.*`, `10.*`, `172.*` and `192.168.*`.

That last one is the real blocker: it is consulted in a dozen places, and every Freenet node a developer can start on their own machine has a loopback or RFC1918 address. So a local dashboard connected to a local network renders empty by construction, and there is no way to develop or review a UI change without pushing it to the gateway first.

## Solution

The four paths become environment overrides that default to exactly today's values, so an unconfigured deployment behaves as it does now:

- `FREENET_TELEMETRY_LOG`
- `FREENET_DASHBOARD_DB`
- `FREENET_PEER_NAMES_FILE`
- `FREENET_DASHBOARD_WS_PORT`

And `FREENET_DASHBOARD_ALLOW_PRIVATE_IPS=1` keeps private-range nodes visible. It is opt-in and must never be set in production, where it would let test and CI nodes into the public topology view. Unset, `is_public_ip()` filters exactly as before.

## Testing

Ran the full stack locally with these overrides: two Freenet gateways exporting OTLP to a local `otelcol-contrib`, `ws_server.py` tailing its output into a scratch database, and the UI served over HTTP. The topology, contracts and timeline panels populate with real traffic from the local network, which is not possible on `main` today.

With every variable unset, the server starts against the production paths unchanged.

## Fixes

Prerequisite for reviewing UI work locally, including the network checks panel that follows.