### PR TITLE
feat: add network checks panel (#4665)

### DIFF
--- a/css/checks.css
+++ b/css/checks.css
@@ -1,0 +1,85 @@
+/* ── Synthetic network checks panel (freenet-core #4665) ─────────────────── */
+#checks-panel-content { flex-direction: column; }
+.checks-container {
+    padding: 12px 14px;
+    overflow-y: auto;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-primary);
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+}
+.checks-empty { color: var(--text-muted); padding: 24px; text-align: center; }
+.checks-grid { display: flex; flex-direction: column; gap: 10px; margin-bottom: 18px; flex: 0 0 auto; }
+.checks-row { display: flex; flex-direction: column; gap: 4px; flex: 0 0 auto; }
+.checks-scenario { display: flex; align-items: baseline; gap: 8px; }
+.checks-name { color: var(--accent-light); }
+.checks-when { color: var(--text-muted); font-size: 10px; }
+.checks-cells { display: flex; gap: 3px; flex-wrap: wrap; }
+.checks-cell {
+    width: 14px; height: 14px; flex: 0 0 auto; box-sizing: border-box; border: 1px solid var(--border-color);
+    border-radius: 2px; padding: 0; cursor: pointer; background: var(--bg-tertiary);
+}
+.checks-cell.selected { outline: 1px solid var(--accent-primary); outline-offset: 1px; }
+.checks-cell.ok { background: var(--color-get); }
+.checks-cell.warn { background: var(--color-put); }
+.checks-cell.bad { background: var(--color-error); }
+.checks-cell.muted { background: var(--text-muted); }
+.checks-verdict { font-size: 10px; text-transform: uppercase; letter-spacing: .04em; }
+.checks-verdict.ok, .checks-table td.ok { color: var(--color-get); }
+.checks-verdict.warn, .checks-table td.warn { color: var(--color-put); }
+.checks-verdict.bad, .checks-table td.bad { color: var(--color-error); }
+.checks-verdict.muted { color: var(--text-muted); }
+.checks-section-title {
+    margin: 14px 0 6px; color: var(--text-secondary);
+    display: flex; align-items: baseline; gap: 8px;
+}
+.checks-table { width: 100%; border-collapse: collapse; }
+.checks-table th {
+    text-align: left; color: var(--text-muted); font-weight: normal;
+    border-bottom: 1px solid var(--border-color); padding: 3px 6px 3px 0;
+}
+.checks-table td { padding: 3px 6px 3px 0; border-bottom: 1px solid rgba(48,54,61,.25); }
+.checks-table tr.bad-row td { background: rgba(248, 113, 113, 0.06); }
+.checks-key, .checks-err {
+    color: var(--text-secondary); max-width: 130px; overflow: hidden;
+    text-overflow: ellipsis; white-space: nowrap;
+}
+.checks-intro { color: var(--text-secondary); margin-bottom: 8px; line-height: 1.5; }
+.checks-legend {
+    display: flex; flex-wrap: wrap; gap: 4px 18px; margin-bottom: 14px;
+    padding-bottom: 12px; border-bottom: 1px solid var(--border-color);
+}
+.checks-legend-item { display: flex; align-items: center; gap: 6px; }
+.checks-legend-item .checks-cell { cursor: default; }
+.checks-empty-title { color: var(--text-secondary); margin-bottom: 8px; }
+.checks-empty { line-height: 1.7; max-width: 42em; margin: 40px auto; }
+.checks-err { max-width: 220px; white-space: normal; overflow: visible; }
+
+/* Matrix view: rows = what was read, columns = runs (oldest left). */
+.checks-scenario-block { margin-bottom: 18px; }
+.checks-mrow { display: flex; align-items: center; gap: 10px; margin: 3px 0; }
+.checks-mlabel {
+    width: 190px; flex: 0 0 auto; display: flex; gap: 8px;
+    color: var(--text-secondary); justify-content: flex-end; text-align: right;
+}
+.checks-op { color: var(--accent-light); }
+.checks-mrate { width: 42px; flex: 0 0 auto; text-align: right; }
+.checks-mmed { width: 56px; flex: 0 0 auto; text-align: right; color: var(--text-muted); }
+.checks-cell.none { background: transparent; border-style: dashed; }
+.checks-axis { color: var(--text-muted); font-size: 10px; height: 13px; }
+.checks-axis .checks-cells { overflow: visible; }
+.checks-slot { width: 17px; flex: 0 0 auto; white-space: nowrap; overflow: visible; }
+.checks-slot .ver { color: var(--accent-light); }
+.checks-tabs { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 14px; }
+.checks-tab {
+    display: flex; align-items: center; gap: 7px; padding: 4px 9px;
+    background: var(--bg-tertiary); border: 1px solid var(--border-color);
+    border-radius: 3px; color: var(--text-secondary);
+    font-family: inherit; font-size: inherit; cursor: pointer;
+}
+.checks-tab:hover { border-color: var(--accent-primary); }
+.checks-tab.active { color: var(--text-primary); border-color: var(--accent-primary); }
+.checks-tab .checks-cell { cursor: pointer; }

--- a/css/styles.css
+++ b/css/styles.css
@@ -12,3 +12,4 @@
 @import url('modals.css?v=20260526a');
 @import url('metrics.css?v=20260701a');
 @import url('responsive.css?v=20260526a');
+@import url('checks.css?v=20260726k');

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@300;400;500;600;700&family=IBM+Plex+Sans:wght@300;400;500;600;700&display=swap" rel="stylesheet">
-    <link rel="stylesheet" href="css/styles.css?v=20260701a">
+    <link rel="stylesheet" href="css/styles.css?v=20260726k">
     <script>
         // Apply saved theme before render to avoid flash of wrong theme.
         // Wrapped in try/catch because localStorage throws in Safari private browsing.
@@ -155,6 +155,7 @@
                             <button class="panel-tab" id="tab-performance" onclick="switchRightTab('performance')">Performance</button>
                             <button class="panel-tab" id="tab-versions" onclick="switchRightTab('versions')">Versions</button>
                             <button class="panel-tab" id="tab-resources" onclick="switchRightTab('resources')">Resources</button>
+                            <button class="panel-tab" id="tab-checks" onclick="switchRightTab('checks')">Checks</button>
                         </div>
                     </div>
                     <div id="contracts-panel-content">
@@ -195,6 +196,14 @@
                             <div class="empty-state">
                                 <div class="empty-state-icon">&#128190;</div>
                                 <div>Loading resource data...</div>
+                            </div>
+                        </div>
+                    </div>
+                    <div id="checks-panel-content" class="performance-panel" style="display: none;">
+                        <div class="checks-container" id="checks-container">
+                            <div class="empty-state">
+                                <div class="empty-state-icon">&#129522;</div>
+                                <div>Loading network checks...</div>
                             </div>
                         </div>
                     </div>
@@ -263,6 +272,6 @@
     </div>
 
 
-    <script type="module" src="js/app.js?v=20260701a"></script>
+    <script type="module" src="js/app.js?v=20260726a"></script>
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -32,6 +32,7 @@ import { updateContractTree, getTreeStats, resetContractTree, triggerTreeMessage
 import { initMetricsChart, updateMetricsChart, destroyMetricsChart } from './metrics.js';
 import { initVersionsChart, updateVersionsChart, destroyVersionsChart } from './versions.js';
 import { initResourcesPanel, updateResourcesPanel, destroyResourcesPanel } from './resources.js';
+import { initChecksPanel, destroyChecksPanel } from './checks.js';
 
 // ============================================================================
 // Main Application Functions
@@ -275,23 +276,28 @@ function switchRightTab(tab) {
     const performanceContent = document.getElementById('performance-panel-content');
     const versionsContent = document.getElementById('versions-panel-content');
     const resourcesContent = document.getElementById('resources-panel-content');
+    const checksContent = document.getElementById('checks-panel-content');
     const tabContracts = document.getElementById('tab-contracts');
     const tabPerformance = document.getElementById('tab-performance');
     const tabVersions = document.getElementById('tab-versions');
     const tabResources = document.getElementById('tab-resources');
+    const tabChecks = document.getElementById('tab-checks');
 
     // Hide all
     contractsContent.style.display = 'none';
     performanceContent.style.display = 'none';
     versionsContent.style.display = 'none';
     resourcesContent.style.display = 'none';
+    if (checksContent) checksContent.style.display = 'none';
     tabContracts.classList.remove('active');
     tabPerformance.classList.remove('active');
     tabVersions.classList.remove('active');
     tabResources.classList.remove('active');
+    if (tabChecks) tabChecks.classList.remove('active');
     destroyMetricsChart();
     destroyVersionsChart();
     destroyResourcesPanel();
+    destroyChecksPanel();
 
     if (tab === 'performance') {
         performanceContent.style.display = 'flex';
@@ -308,6 +314,10 @@ function switchRightTab(tab) {
         tabResources.classList.add('active');
         const container = document.getElementById('resources-container');
         initResourcesPanel(container);
+    } else if (tab === 'checks') {
+        checksContent.style.display = 'flex';
+        tabChecks.classList.add('active');
+        initChecksPanel(document.getElementById('checks-container'));
     } else {
         contractsContent.style.display = '';
         tabContracts.classList.add('active');

--- a/js/checks.js
+++ b/js/checks.js
@@ -1,0 +1,329 @@
+/**
+ * Synthetic network checks panel (freenet-core #4665).
+ *
+ * Results of checks that exercise the live network as a client would. Data
+ * arrives in `state.checks` and is updated live by `check` messages.
+ *
+ * Nothing here may enumerate scenarios, dimensions or operation kinds. They
+ * are discovered from the data, so a new check lights up with no code change.
+ */
+
+import { state } from './state.js';
+
+// Wording stays scenario-neutral on purpose: which failures a check treats as
+// non-critical is the check's own policy, and naming one check's dimensions
+// here would make the legend wrong for every other one.
+const VERDICTS = {
+    pass: { label: 'pass', cls: 'ok', help: 'every operation succeeded' },
+    degraded: { label: 'degraded', cls: 'warn', help: 'only failures the check treats as non-critical' },
+    fail: { label: 'fail', cls: 'bad', help: 'a critical operation failed' },
+    error: { label: 'error', cls: 'muted', help: 'the check could not run, so it says nothing about the network' },
+};
+
+const EMPTY_HELP = 'Synthetic checks publish contracts to the live network and read them back '
+    + 'from a freshly joined peer, then again on later nights. Results appear here '
+    + 'once a check reports.';
+
+let container = null;
+let selectedKey = null;
+let selectedScenario = null;
+
+function checks() {
+    return state.checks || { runs: [], ops: [], scenarios: [] };
+}
+
+/** Run identity is (scenario, run_id): run ids are nightly timestamps. */
+function runKey(scenario, runId) {
+    return `${scenario}::${runId}`;
+}
+
+function verdictInfo(v) {
+    return VERDICTS[v] || { label: v || 'unknown', cls: 'muted' };
+}
+
+function fmtAgo(tsNs) {
+    const ms = Date.now() - tsNs / 1e6;
+    if (!isFinite(ms) || ms < 0) return '';
+    const h = ms / 3600000;
+    if (h < 1) return `${Math.round(ms / 60000)}m ago`;
+    if (h < 48) return `${Math.round(h)}h ago`;
+    return `${Math.round(h / 24)}d ago`;
+}
+
+/**
+ * Human wording for a dimension, derived from its numeric form so that a
+ * scenario the panel has never seen still reads sensibly. Labels without a
+ * numeric form (a hop, a phase) are shown as-is.
+ */
+function dimensionLabel(dim, secs) {
+    if (secs == null) return dim || '';
+    if (secs === 0) return 'same run';
+    const days = secs / 86400;
+    return days >= 1
+        ? `published ${days % 1 === 0 ? days : days.toFixed(1)}d earlier`
+        : `published ${Math.round(secs / 3600)}h earlier`;
+}
+
+function esc(s) {
+    return String(s ?? '').replace(/[&<>"']/g, c => (
+        { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+    ));
+}
+
+function renderLegend() {
+    const items = Object.values(VERDICTS).map(v =>
+        `<div class="checks-legend-item">
+            <span class="checks-cell ${v.cls}"></span>
+            <span class="checks-verdict ${v.cls}">${v.label}</span>
+            <span class="checks-when">${v.help}</span>
+        </div>`).join('');
+    return `<div class="checks-intro">
+                One column per run, oldest on the left. A row that turns red is a
+                regression; an empty cell means that read was not due yet.
+            </div>
+            <div class="checks-legend">${items}
+                <div class="checks-legend-item">
+                    <span class="checks-cell none"></span>
+                    <span class="checks-when">not exercised in that run</span>
+                </div>
+            </div>`;
+}
+
+const MAX_COLUMNS = 40;
+
+function fmtBytes(n) {
+    if (n == null) return '';
+    return n >= 1024 * 1024 ? `${(n / 1048576).toFixed(1)} MB`
+        : n >= 1024 ? `${Math.round(n / 1024)} KB` : `${n} B`;
+}
+
+function fmtDay(tsNs) {
+    return new Date(tsNs / 1e6).toLocaleDateString(undefined, { day: 'numeric', month: 'short' });
+}
+
+function median(values) {
+    const v = values.filter(x => x != null).sort((a, b) => a - b);
+    return v.length ? v[Math.floor(v.length / 2)] : null;
+}
+
+function renderSelector(runs) {
+    const latest = new Map();
+    for (const r of runs) if (!latest.has(r.scenario)) latest.set(r.scenario, r);
+    if (latest.size < 2) return '';
+    return `<div class="checks-tabs">` + [...latest.entries()].sort()
+        .map(([name, r]) => {
+            const v = verdictInfo(r.verdict);
+            const on = name === selectedScenario ? ' active' : '';
+            return `<button class="checks-tab${on}" onclick="selectCheckScenario('${esc(name)}')">
+                <span class="checks-cell ${v.cls}"></span>
+                <span>${esc(name)}</span>
+                <span class="checks-when">${esc(fmtAgo(r.timestamp_ns))}</span>
+            </button>`;
+        }).join('') + `</div>`;
+}
+
+/**
+ * The panel's core view: per scenario, a matrix of what was read (rows) against
+ * runs (columns). One dimension degrading over time is the signal a nightly
+ * check exists to produce, and a per-run verdict alone cannot show it.
+ */
+function renderMatrix(runs, ops) {
+    let html = '';
+    for (const scenario of [selectedScenario]) {
+        // Oldest first: this axis is time, and time reads left to right.
+        const cols = runs.filter(r => r.scenario === scenario)
+            .slice(0, MAX_COLUMNS).reverse();
+        if (!cols.length) continue;
+        const colIndex = new Map(cols.map((r, i) => [r.run_id, i]));
+
+        const rows = new Map();
+        for (const o of ops) {
+            if (o.scenario !== scenario) continue;
+            const i = colIndex.get(o.run_id);
+            if (i == null) continue;
+            const k = `${o.op} ${o.dimension || '-'}`;
+            const row = rows.get(k) || {
+                op: o.op, dim: o.dimension || '-', secs: o.dimension_secs,
+                cells: cols.map(() => null), lat: cols.map(() => null),
+            };
+            row.cells[i] = row.cells[i] === false ? false : !!o.ok;
+            if (o.ok && o.latency_ms != null) row.lat[i] = o.latency_ms;
+            rows.set(k, row);
+        }
+
+        const body = [...rows.values()]
+            .sort((a, b) => ((a.secs ?? 1e12) - (b.secs ?? 1e12))
+                || a.op.localeCompare(b.op) || a.dim.localeCompare(b.dim))
+            .map(row => {
+                const cells = row.cells.map((ok, i) => {
+                    const r = cols[i];
+                    const cls = ok === null ? 'none' : ok ? 'ok' : 'bad';
+                    const sel = runKey(scenario, r.run_id) === selectedKey ? ' selected' : '';
+                    const state = ok === null ? 'not due' : ok ? 'ok' : 'FAILED';
+                    const tip = `${r.run_id} · ${row.op} ${dimensionLabel(row.dim, row.secs)} · ${state}`;
+                    return `<button class="checks-cell ${cls}${sel}" title="${esc(tip)}"
+                        onclick="selectCheckRun('${esc(scenario)}','${esc(r.run_id)}')"></button>`;
+                }).join('');
+                const done = row.cells.filter(c => c !== null);
+                const rate = done.length ? 100 * done.filter(Boolean).length / done.length : 0;
+                const cls = rate === 100 ? 'ok' : rate >= 80 ? 'warn' : 'bad';
+                const med = median(row.lat);
+                return `<div class="checks-mrow">
+                    <div class="checks-mlabel">
+                        <span class="checks-op">${esc(row.op)}</span>
+                        <span>${esc(dimensionLabel(row.dim, row.secs))}</span>
+                    </div>
+                    <div class="checks-cells">${cells}</div>
+                    <div class="checks-mrate ${cls}">${rate.toFixed(0)}%</div>
+                    <div class="checks-mmed">${med == null ? '' : Math.round(med) + ' ms'}</div>
+                </div>`;
+            }).join('');
+
+        // Both axes share the cells' 17px slots so they line up without
+        // absolute positioning, and skip labels that would collide.
+        const axis = (wanted, text, minGap) => {
+            let last = -Infinity;
+            return cols.map((r, i) => {
+                const show = wanted(r, i) && i - last >= minGap;
+                if (show) last = i;
+                return `<span class="checks-slot">${show ? text(r, i) : ''}</span>`;
+            }).join('');
+        };
+
+        const dateAxis = axis(
+            (r, i) => i === 0 || i === cols.length - 1 || i % 5 === 0,
+            r => esc(fmtDay(r.timestamp_ns)), 4);
+
+        // Only where the version CHANGES: the correlation a maintainer reaches
+        // for as soon as a row starts going red.
+        const versionOf = r => (r.software_version || '').match(/\d+\.\d+\.\d+/)?.[0] || '';
+        const versionAxis = axis(
+            (r, i) => versionOf(r) && (i === 0 || versionOf(r) !== versionOf(cols[i - 1])),
+            r => `<span class="ver">▲${esc(versionOf(r))}</span>`, 4);
+
+        const newest = cols[cols.length - 1];
+        const latest = verdictInfo(newest.verdict);
+        html += `<div class="checks-scenario-block">
+            <div class="checks-scenario">
+                <span class="checks-name">${esc(scenario)}</span>
+                <span class="checks-verdict ${latest.cls}">${esc(latest.label)}</span>
+                <span class="checks-when">${cols.length} runs</span>
+            </div>
+            <div class="checks-mrow checks-axis">
+                <div class="checks-mlabel"></div><div class="checks-cells">${dateAxis}</div>
+            </div>
+            ${body}
+            <div class="checks-mrow checks-axis">
+                <div class="checks-mlabel"></div><div class="checks-cells">${versionAxis}</div>
+            </div>
+        </div>`;
+    }
+    return html;
+}
+
+function renderRunDetail(runs, ops) {
+    const run = runs.find(r => runKey(r.scenario, r.run_id) === selectedKey);
+    if (!run) return '';
+    const v = verdictInfo(run.verdict);
+    const runOps = ops.filter(o => o.run_id === run.run_id && o.scenario === run.scenario);
+    const rows = runOps.map(o => `<tr class="${o.ok ? '' : 'bad-row'}" title="${esc(o.contract_key || '')}">
+            <td>${esc(o.op)}</td>
+            <td>${esc(dimensionLabel(o.dimension, o.dimension_secs))}</td>
+            <td class="${o.ok ? 'ok' : 'bad'}">${o.ok ? 'ok' : 'FAIL'}</td>
+            <td>${o.latency_ms == null ? '' : Math.round(o.latency_ms) + ' ms'}</td>
+            <td>${fmtBytes(o.bytes)}</td>
+            <td class="checks-err">${esc(o.error || '')}</td>
+        </tr>`).join('');
+    const failed = runOps.filter(o => !o.ok);
+    const summary = failed.length
+        ? `${failed.length} of ${runOps.length} operations failed: ${v.help}`
+        : `all ${runOps.length} operations succeeded`;
+    return `<div class="checks-section-title">
+            Run ${esc(run.run_id)}
+            <span class="checks-verdict ${v.cls}">${esc(v.label)}</span>
+            <span class="checks-when">${esc(run.vantage)} · ${esc(run.software_version || '')}</span>
+        </div>
+        <div class="checks-intro">${esc(summary)}</div>
+        <table class="checks-table">
+            <thead><tr><th>op</th><th>what was read</th><th>result</th><th>latency</th>
+                <th>size</th><th>error</th></tr></thead>
+            <tbody>${rows}</tbody>
+        </table>`;
+}
+
+function render() {
+    if (!container) return;
+    const { runs, ops } = checks();
+    if (!runs.length) {
+        container.innerHTML = `<div class="checks-empty">
+            <div class="checks-empty-title">No check results yet</div>
+            <div>${esc(EMPTY_HELP)}</div>
+        </div>`;
+        return;
+    }
+    if (!selectedScenario || !runs.some(r => r.scenario === selectedScenario)) {
+        selectedScenario = runs[0].scenario;
+    }
+    if (!selectedKey || !runs.some(r => runKey(r.scenario, r.run_id) === selectedKey
+                                        && r.scenario === selectedScenario)) {
+        const first = runs.find(r => r.scenario === selectedScenario);
+        selectedKey = runKey(first.scenario, first.run_id);
+    }
+    container.innerHTML = renderLegend()
+        + renderSelector(runs)
+        + renderMatrix(runs, ops)
+        + renderRunDetail(runs, ops);
+}
+
+export function initChecksPanel(el) {
+    container = el;
+    render();
+}
+
+export function destroyChecksPanel() {
+    container = null;
+}
+
+export function setChecks(payload) {
+    state.checks = payload || { runs: [], ops: [], scenarios: [] };
+    render();
+}
+
+/** Fold a live `check` message into the loaded state. */
+export function applyCheckEvent(msg) {
+    if (!state.checks) state.checks = { runs: [], ops: [], scenarios: [] };
+    const c = state.checks;
+    if (msg.event_type === 'netcheck_run') {
+        c.runs = c.runs.filter(r => !(r.run_id === msg.run_id && r.scenario === msg.scenario));
+        c.runs.unshift({
+            run_id: msg.run_id, scenario: msg.scenario, vantage: msg.vantage,
+            timestamp_ns: msg.timestamp, duration_ms: msg.duration_ms,
+            verdict: msg.verdict, ops_total: msg.ops_total,
+            ops_failed: msg.ops_failed, software_version: msg.software_version,
+        });
+        c.runs.sort((a, b) => b.timestamp_ns - a.timestamp_ns);
+        if (!c.scenarios.includes(msg.scenario)) c.scenarios.push(msg.scenario);
+    } else {
+        c.ops.push({
+            run_id: msg.run_id, scenario: msg.scenario, vantage: msg.vantage,
+            timestamp_ns: msg.timestamp, op: msg.op, dimension: msg.dimension,
+            dimension_secs: msg.dimension_secs, contract_key: msg.contract_key,
+            ok: msg.ok ? 1 : 0, latency_ms: msg.latency_ms, bytes: msg.bytes,
+            error: msg.error,
+        });
+    }
+    render();
+}
+
+export function selectCheckRun(scenario, runId) {
+    selectedKey = runKey(scenario, runId);
+    render();
+}
+window.selectCheckRun = selectCheckRun;
+
+export function selectCheckScenario(scenario) {
+    selectedScenario = scenario;
+    selectedKey = null;
+    render();
+}
+window.selectCheckScenario = selectCheckScenario;

--- a/js/events.js
+++ b/js/events.js
@@ -322,13 +322,15 @@ export function loadFromURL(updateView) {
         }
     }
 
-    // Restore right panel tab
+    // Restore right panel tab. updateURL() writes whichever tab is open, so
+    // restoring only 'performance' silently dropped every other one: a
+    // shared link to Versions, Resources or Checks landed back on Contracts.
     const tabParam = params.get('tab');
-    if (tabParam === 'performance') {
-        state.rightPanelTab = 'performance';
+    if (['performance', 'versions', 'resources', 'checks'].includes(tabParam)) {
+        state.rightPanelTab = tabParam;
         // Defer tab switch to after DOM is ready
         setTimeout(() => {
-            if (window.switchRightTab) window.switchRightTab('performance');
+            if (window.switchRightTab) window.switchRightTab(tabParam);
         }, 0);
     }
 

--- a/js/websocket.js
+++ b/js/websocket.js
@@ -6,6 +6,7 @@
 import { state } from './state.js';
 import { addTransferEvents, addTransferEvent } from './transfers.js';
 import { setPeerResources, updatePeerResource } from './resources.js';
+import { setChecks, applyCheckEvent } from './checks.js';
 import { formatLatency, getRateClass, indexEventForActivity, clearActivityIndex, rebuildActivityIndex } from './utils.js';
 
 /**
@@ -202,6 +203,13 @@ function handleMessage(data, callbacks) {
             console.log('Peer resources:', Object.keys(data.peer_resources).length);
         }
 
+        // Load synthetic network check results (#4665)
+        if (data.checks) {
+            setChecks(data.checks);
+            console.log('Network checks:', data.checks.runs.length, 'runs,',
+                        data.checks.scenarios.length, 'scenario(s)');
+        }
+
         // Store peer and connection data
         if (data.peers) {
             state.initialStatePeers = data.peers;
@@ -300,6 +308,9 @@ function handleMessage(data, callbacks) {
     } else if (data.type === 'resource') {
         // Real-time per-node resource-utilization sample (#4642 A1)
         updatePeerResource(data);
+    } else if (data.type === 'check') {
+        // Real-time synthetic check result (#4665)
+        applyCheckEvent(data);
     } else if (data.type === 'peer_name_update') {
         state.peerNames[data.ip_hash] = data.name;
         console.log(`Peer ${data.ip_hash} named: ${data.name}${data.was_modified ? ' (adjusted)' : ''}`);

--- a/telemetry_db.py
+++ b/telemetry_db.py
@@ -94,6 +94,43 @@ CREATE TABLE IF NOT EXISTS meta (
     key TEXT PRIMARY KEY,
     value TEXT
 );
+
+-- Synthetic network checks (freenet-core #4665). Separate tables because the
+-- value here is the multi-week trend: the 48h prune that the telemetry
+-- firehose needs would delete a 7-day retention series before it could be
+-- plotted. prune() must never touch these.
+-- Keyed by (scenario, run_id): run ids are the nightly's timestamp, so two
+-- checks running the same night would otherwise overwrite each other.
+CREATE TABLE IF NOT EXISTS check_runs (
+    run_id           TEXT    NOT NULL,
+    scenario         TEXT    NOT NULL,   -- "put_get", "update_propagation", ...
+    vantage          TEXT    NOT NULL,   -- where it ran from: "nova", "ci", ...
+    timestamp_ns     INTEGER NOT NULL,
+    duration_ms      INTEGER,
+    verdict          TEXT    NOT NULL,   -- pass | degraded | fail | error
+    ops_total        INTEGER,
+    ops_failed       INTEGER,
+    software_version TEXT,
+    conditions       TEXT,              -- JSON blob, UI-opaque
+    PRIMARY KEY (scenario, run_id)
+);
+
+CREATE TABLE IF NOT EXISTS check_ops (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    run_id         TEXT    NOT NULL,
+    scenario       TEXT    NOT NULL,
+    vantage        TEXT    NOT NULL,
+    timestamp_ns   INTEGER NOT NULL,
+    op             TEXT    NOT NULL,     -- put | get | update | subscribe | ...
+    dimension      TEXT,                 -- "0h", "24h", "7d", "join", ...
+    dimension_secs INTEGER,              -- numeric form for ordering; NULL if N/A
+    contract_key   TEXT,                 -- join key into events/transactions/flows
+    ok             INTEGER NOT NULL,
+    latency_ms     REAL,
+    bytes          INTEGER,
+    error          TEXT,
+    extra          TEXT                  -- JSON blob, UI-opaque
+);
 """
 
 # Indexes are created separately so they can be deferred on large DBs.
@@ -112,6 +149,10 @@ SCHEMA_INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_flows_ts ON flows(timestamp_ns)",
     "CREATE INDEX IF NOT EXISTS idx_flows_tx ON flows(tx_id) WHERE tx_id IS NOT NULL",
     "CREATE INDEX IF NOT EXISTS idx_flows_type_ts ON flows(event_type, timestamp_ns)",
+    "CREATE INDEX IF NOT EXISTS idx_check_runs_scenario_ts ON check_runs(scenario, timestamp_ns)",
+    "CREATE INDEX IF NOT EXISTS idx_check_ops_scenario_ts ON check_ops(scenario, timestamp_ns)",
+    "CREATE INDEX IF NOT EXISTS idx_check_ops_run ON check_ops(scenario, run_id)",
+    "CREATE INDEX IF NOT EXISTS idx_check_ops_contract ON check_ops(contract_key) WHERE contract_key IS NOT NULL",
 ]
 
 
@@ -876,6 +917,103 @@ class TelemetryDB:
             (key, str(value)),
         )
 
+    # ---- Network checks (freenet-core #4665) ----
+    #
+    # Unbuffered: a few rows a night, so batching would only add a window in
+    # which a restart loses a night's verdict.
+
+    def insert_check_run(self, body):
+        if not self._enabled:
+            return
+        try:
+            self.conn.execute(
+                "INSERT OR REPLACE INTO check_runs (run_id, scenario, vantage, "
+                "timestamp_ns, duration_ms, verdict, ops_total, ops_failed, "
+                "software_version, conditions) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    body.get("run_id"),
+                    body.get("scenario", "unknown"),
+                    body.get("vantage", "unknown"),
+                    int(body.get("timestamp") or 0),
+                    body.get("duration_ms"),
+                    body.get("verdict", "unknown"),
+                    body.get("ops_total"),
+                    body.get("ops_failed"),
+                    body.get("software_version"),
+                    orjson.dumps(body.get("conditions") or {}).decode(),
+                ),
+            )
+        except Exception as e:
+            print(f"[db] insert_check_run error: {e}")
+
+    def insert_check_op(self, body):
+        if not self._enabled:
+            return
+        try:
+            self.conn.execute(
+                "INSERT INTO check_ops (run_id, scenario, vantage, timestamp_ns, op, "
+                "dimension, dimension_secs, contract_key, ok, latency_ms, bytes, "
+                "error, extra) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    body.get("run_id"),
+                    body.get("scenario", "unknown"),
+                    body.get("vantage", "unknown"),
+                    int(body.get("timestamp") or 0),
+                    body.get("op", "unknown"),
+                    body.get("dimension"),
+                    body.get("dimension_secs"),
+                    body.get("contract_key"),
+                    1 if body.get("ok") else 0,
+                    body.get("latency_ms"),
+                    body.get("bytes"),
+                    body.get("error"),
+                    orjson.dumps(body.get("extra")).decode() if body.get("extra") else None,
+                ),
+            )
+        except Exception as e:
+            print(f"[db] insert_check_op error: {e}")
+
+    def get_check_state(self, run_limit=60):
+        """Everything the checks panel needs, in one round trip.
+
+        Scenarios and dimensions are discovered from the data, never enumerated:
+        a new scenario must light up the panel with no dashboard change.
+        """
+        if not self._enabled or not self.conn:
+            return {"runs": [], "ops": [], "scenarios": []}
+        try:
+            run_cols = ("run_id", "scenario", "vantage", "timestamp_ns", "duration_ms",
+                        "verdict", "ops_total", "ops_failed", "software_version")
+            runs = [
+                dict(zip(run_cols, r))
+                for r in self.conn.execute(
+                    f"SELECT {', '.join(run_cols)} FROM check_runs "
+                    "ORDER BY timestamp_ns DESC LIMIT ?", (run_limit,)
+                )
+            ]
+            op_cols = ("run_id", "scenario", "vantage", "timestamp_ns", "op", "dimension",
+                       "dimension_secs", "contract_key", "ok", "latency_ms", "bytes", "error")
+            if runs:
+                # Match on (scenario, run_id): run ids repeat across scenarios.
+                pairs = [(r["scenario"], r["run_id"]) for r in runs]
+                clause = " OR ".join(["(scenario = ? AND run_id = ?)"] * len(pairs))
+                params = [v for pair in pairs for v in pair]
+                ops = [
+                    dict(zip(op_cols, r))
+                    for r in self.conn.execute(
+                        f"SELECT {', '.join(op_cols)} FROM check_ops "
+                        f"WHERE {clause} ORDER BY timestamp_ns", params
+                    )
+                ]
+            else:
+                ops = []
+            scenarios = [r[0] for r in self.conn.execute(
+                "SELECT DISTINCT scenario FROM check_runs ORDER BY scenario")]
+            return {"runs": runs, "ops": ops, "scenarios": scenarios}
+        except Exception as e:
+            print(f"[db] get_check_state error: {e}")
+            return {"runs": [], "ops": [], "scenarios": []}
+
     # ---- Maintenance ----
 
     def prune(self, retention_ns=DEFAULT_RETENTION_NS,
@@ -895,6 +1033,8 @@ class TelemetryDB:
         total = 0
         hit_budget = False
         try:
+            # check_runs/check_ops are deliberately absent: their retention is
+            # measured in weeks, not hours (see SCHEMA_TABLES).
             while True:
                 if time.monotonic() >= deadline:
                     hit_budget = True

--- a/ws_server.py
+++ b/ws_server.py
@@ -1353,6 +1353,21 @@ def process_record(record, store_history=True):
     if not event_type:
         return None
 
+    # Synthetic network checks (freenet-core #4665). Handled before any peer
+    # parsing: these report from a client, so they have no peer IP and the
+    # `if not display_ip` guard below would drop them. They also skip
+    # HISTORY_EVENT_TYPES: check results have their own tables and are not
+    # subject to the 24h prune.
+    #
+    # A new kind of check is a new `scenario` value, never a new event type.
+    if event_type in ("netcheck_run", "netcheck_op"):
+        body.setdefault("timestamp", timestamp)
+        if event_type == "netcheck_run":
+            db.insert_check_run(body)
+        else:
+            db.insert_check_op(body)
+        return {"type": "check", "event_type": event_type, **body}
+
     # Get body type for more specific event types (especially for connect events)
     # event_type from attrs is generic ("connect"), body type is specific ("start_connection", "connected", "finished")
     body_type = body.get("type", "")
@@ -2320,6 +2335,7 @@ def get_network_state():
         "propagation": get_propagation_data(),  # State propagation timelines
         "metrics_timeseries": get_metrics_timeseries(),
         "version_rollout": get_version_rollout(),
+        "checks": db.get_check_state(),  # synthetic network checks (#4665)
     }
 
 
@@ -2630,6 +2646,10 @@ async def tail_log():
                                     # Low-volume node self-resource samples (#4642
                                     # A1): broadcast live on their own message type,
                                     # decoupled from the event/transaction pipeline.
+                                    await broadcast(event)
+                                elif event and event.get("type") == "check":
+                                    # Already persisted by process_record (#4665);
+                                    # broadcast so an open panel updates live.
                                     await broadcast(event)
                                 elif event and event["event_type"] in REALTIME_EVENT_TYPES:
                                     await buffer_event(event)  # Buffer for batched sending


### PR DESCRIPTION
## Problem

freenet-core is adding `netcheck` (freenet/freenet-core#4949), a synthetic check that publishes contracts to the live network every night and reads them back, including re-reads of contracts published on previous nights to measure real 24 h / 48 h / 7 d retention. Its results have nowhere to go.

They cannot go into `events`. That table is pruned at 48 h, correctly, because it holds the node telemetry firehose at roughly 46 GB/day. But the entire value of a nightly check is the multi-week trend, and a 48-hour window cannot hold even one 7-day data point. Check results are around 10 rows a night, so they are a different storage class, not a different volume of the same one.

## Solution

Two new tables, `check_runs` and `check_ops`, with their own long retention. `prune()` does not touch them. They join the existing tables on `contract_key`, so within the 48-hour window a failed check can still be drilled into the actual peer-to-peer hop path in `flows`, and after that the verdict survives while the hops do not.

Ingestion reuses the OTLP collector already listening on 4318. `process_record` handles the two check event types before any peer parsing, because a check reports from a client: it has no peer IP and would otherwise be dropped by the `if not display_ip: return None` guard, the same way `resource_utilization` was until #4642 A1.

The panel (`js/checks.js`, `css/checks.css`, plus a tab) is built around one constraint: **adding a new kind of check must cost zero dashboard changes**. There are only two event types, `netcheck_run` and `netcheck_op`, and a new check is a new `scenario` value, never a new type. Nothing in the panel enumerates scenarios, dimensions or operation kinds; they are all discovered from the data.

The main view is a matrix per scenario: rows are what was read, columns are runs with the oldest on the left. A dimension degrading over weeks shows up as a row going red from left to right, which a per-run verdict cannot express. Below the columns sit markers wherever the reported `software_version` changes, so "what broke" and "what changed" share an axis.

## Testing

Reviewing this locally needs the environment overrides from the companion PR, without which the dashboard renders empty against any network a developer can run.

Exercised end to end against a local stack: two linked Freenet gateways exporting OTLP to a local `otelcol-contrib`, `ws_server.py` tailing its output into a scratch database, and a real `netcheck` run publishing and reading back contracts.

The acceptance criterion was tested rather than assumed. A fabricated `update_propagation` scenario, with `hop-1` / `hop-2` / `hop-3` dimensions and a check that does not exist, rendered its own selector entry, its own matrix and its own success rates with no code change.

Feeding a second scenario also caught a schema bug before it shipped: `run_id` alone is not unique, since run ids are the nightly's timestamp, so two checks running the same night overwrote each other through `INSERT OR REPLACE`. The key is now `(scenario, run_id)`.

## Notes

The panel is inert until something emits `netcheck_run` / `netcheck_op`: the tables stay empty, the ingest branch never fires, and the tab shows an empty state explaining what it is for. Merging this before freenet-core starts emitting changes nothing else in the dashboard.

`js/events.js` also gained a one-line fix: the URL tab restore only handled `performance`, so a shared link to Versions, Resources or Checks landed back on Contracts.

## Fixes

Part of freenet/freenet-core#4665. Consumes the output of freenet/freenet-core#4949.
