### PR TITLE
fix: measure op outcomes instead of reading transactions.status

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,43 @@
+name: tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: pip install -r requirements-dev.txt
+      - name: Run tests
+        run: python -m pytest tests/ -v
+
+  syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Byte-compile the Python entry points
+        run: python -m py_compile ws_server.py telemetry_db.py backfill_db.py create_indexes.py
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Parse the browser modules
+        # The dashboard ships plain ES modules with no build step, so a syntax
+        # error would only surface in the browser.
+        #
+        # `node --check <file>` silently passes invalid ES modules on Node 22
+        # (verified: a file containing `let x = ;` exits 0). Feeding the source
+        # on stdin with --input-type=module is the form that actually parses.
+        run: |
+          for f in js/*.js; do
+            node --input-type=module --check < "$f" || { echo "syntax error in $f"; exit 1; }
+          done

--- a/backfill_db.py
+++ b/backfill_db.py
@@ -191,7 +191,7 @@ def main():
     """)
 
     event_buf = []
-    tx_data = {}  # tx_id -> {op, contract, start_ns, end_ns, status, events: [...]}
+    tx_data = {}  # tx_id -> {op, contract, start_ns, end_ns, tx_shape, outcome, events}
     count = 0
     stored = 0
     skipped = 0

--- a/backfill_db.py
+++ b/backfill_db.py
@@ -29,8 +29,10 @@ HISTORY_HOURS = 48
 HISTORY_EVENT_TYPES = {
     "put_request", "put_success",
     "get_request", "get_success", "get_not_found", "get_failure",
+    "get_terminal",
     "update_request", "update_success", "update_failure",
     "subscribe_request", "subscribe_success", "subscribe_not_found",
+    "subscribe_timeout",
     "update_broadcast_received", "update_broadcast_applied",
     "update_broadcast_emitted", "broadcast_emitted",
     "update_broadcast_delivery_summary",
@@ -41,6 +43,27 @@ HISTORY_EVENT_TYPES = {
 }
 
 TRACKED_TX_OPS = {"put", "get", "update", "broadcast", "connect", "subscribe"}
+
+# Must mirror TX_START_EVENTS / TX_TERMINAL_EVENTS in ws_server.py. get_success
+# and get_not_found are per-HOP and so are NOT terminals; get_terminal is the
+# client-facing GET outcome and is handled inline (its result is in the body).
+TX_START_EVENTS = {
+    "put_request", "get_request", "update_request",
+    "subscribe_request", "connect_request_sent",
+}
+TX_TERMINAL_EVENTS = {
+    "put_success": "success",
+    "put_failure": "failure",
+    "update_success": "success",
+    "update_failure": "failure",
+    "subscribe_success": "success",
+    "subscribe_not_found": "not_found",
+    "subscribe_timeout": "timeout",
+    "subscribed": "success",  # legacy alias, no longer emitted
+    "connect_connected": "success",
+    "connect_rejected": "rejected",
+    "disconnect": "disconnected",
+}
 
 PEER_PATTERN = re.compile(r'(\w+)@(\d+\.\d+\.\d+\.\d+):(\d+)\s*\(@\s*([\d.]+)\)')
 
@@ -141,7 +164,8 @@ def main():
             contract_short TEXT,
             start_ns INTEGER NOT NULL,
             end_ns INTEGER,
-            status TEXT DEFAULT 'pending',
+            tx_shape TEXT DEFAULT 'partial',
+            outcome TEXT,
             duration_ms REAL,
             event_count INTEGER DEFAULT 0
         );
@@ -287,7 +311,7 @@ def main():
                                     tx_data[tx_id] = {
                                         "op": op, "contract": contract_key,
                                         "start_ns": ts, "end_ns": ts,
-                                        "status": "pending",
+                                        "tx_shape": "partial", "outcome": None,
                                         "events": [],
                                     }
                                 tx = tx_data[tx_id]
@@ -296,10 +320,21 @@ def main():
                                     tx["start_ns"] = ts
                                 if ts > tx["end_ns"]:
                                     tx["end_ns"] = ts
-                                # Detect completion
-                                if display_type in ("put_success", "get_success", "get_not_found",
-                                                    "update_success", "subscribed"):
-                                    tx["status"] = "success"
+                                # Shape/outcome must match ws_server.py. The old
+                                # rule here marked get_not_found as "success"
+                                # and keyed subscribes off the never-emitted
+                                # `subscribed` (issue #15).
+                                if display_type in TX_START_EVENTS:
+                                    if tx["tx_shape"] == "partial":
+                                        tx["tx_shape"] = "open"
+                                elif display_type in TX_TERMINAL_EVENTS:
+                                    tx["tx_shape"] = "settled"
+                                    tx["outcome"] = TX_TERMINAL_EVENTS[display_type]
+                                elif display_type == "get_terminal":
+                                    outcome = body.get("outcome")
+                                    if outcome:
+                                        tx["tx_shape"] = "settled"
+                                        tx["outcome"] = outcome
 
                         stored += 1
 
@@ -344,7 +379,8 @@ def main():
         duration_ms = (tx["end_ns"] - tx["start_ns"]) / 1_000_000 if tx["end_ns"] else None
         tx_rows.append((
             tx_id, tx["op"], tx["contract"], contract_short,
-            tx["start_ns"], tx["end_ns"], tx["status"], duration_ms, len(tx["events"])
+            tx["start_ns"], tx["end_ns"], tx["tx_shape"], tx["outcome"],
+            duration_ms, len(tx["events"])
         ))
 
         for ts, et, pid in tx["events"]:
@@ -367,8 +403,9 @@ def main():
     conn.execute("BEGIN")
     conn.executemany(
         "INSERT OR REPLACE INTO transactions "
-        "(tx_id, op, contract_key, contract_short, start_ns, end_ns, status, duration_ms, event_count) "
-        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        "(tx_id, op, contract_key, contract_short, start_ns, end_ns, tx_shape, "
+        "outcome, duration_ms, event_count) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
         tx_rows,
     )
     conn.executemany(

--- a/js/events.js
+++ b/js/events.js
@@ -353,6 +353,58 @@ export function isURLLoaded() {
     return urlLoaded;
 }
 
+// ── Transaction classification — mirrors ws_server.py (issue #15) ──────────
+//
+// A transaction carries two independent facts: `tx_shape` (what we OBSERVED:
+// 'open' / 'settled' / 'partial') and `outcome` (what was MEASURED, and only
+// when tx_shape === 'settled'). They replaced a single `status` field whose
+// 'complete' value really meant "the first event we saw wasn't a start event".
+// Keep these tables in step with TX_START_EVENTS / TX_TERMINAL_EVENTS in
+// ws_server.py — the server and this client must classify identically.
+
+const TX_START_EVENTS = {
+    put_request: 'put',
+    get_request: 'get',
+    update_request: 'update',
+    subscribe_request: 'subscribe',
+    connect_request_sent: 'connect',
+};
+
+// get_success / get_not_found are deliberately ABSENT: the core emits them once
+// per HOP, so settling on one reports a relay's local view as the client's.
+// get_terminal is the only client-facing GET outcome and is handled separately
+// because its outcome comes from the event body.
+const TX_TERMINAL_EVENTS = {
+    put_success: ['put', 'success'],
+    put_failure: ['put', 'failure'],
+    update_success: ['update', 'success'],
+    update_failure: ['update', 'failure'],
+    subscribe_success: ['subscribe', 'success'],
+    subscribe_not_found: ['subscribe', 'not_found'],
+    subscribe_timeout: ['subscribe', 'timeout'],
+    // Legacy alias; no current core release emits `subscribed`.
+    subscribed: ['subscribe', 'success'],
+    connect_connected: ['connect', 'success'],
+    connect_rejected: ['connect', 'rejected'],
+    disconnect: ['disconnect', 'disconnected'],
+};
+
+/**
+ * Map an event type to { op, role } where role is 'start', 'terminal' or null.
+ */
+export function classifyTxEvent(eventType) {
+    if (TX_START_EVENTS[eventType]) return { op: TX_START_EVENTS[eventType], role: 'start' };
+    if (TX_TERMINAL_EVENTS[eventType]) return { op: TX_TERMINAL_EVENTS[eventType][0], role: 'terminal' };
+    if (eventType === 'get_terminal') return { op: 'get', role: 'terminal' };
+    if (eventType.startsWith('put_')) return { op: 'put', role: null };
+    if (eventType.startsWith('get_')) return { op: 'get', role: null };
+    if (eventType.startsWith('update_')) return { op: 'update', role: null };
+    if (eventType.startsWith('subscribe') || eventType === 'unsubscribed') return { op: 'subscribe', role: null };
+    if (eventType.startsWith('connect')) return { op: 'connect', role: null };
+    if (eventType.includes('broadcast')) return { op: 'broadcast', role: null };
+    return { op: eventType.split('_')[0] || 'other', role: null };
+}
+
 /**
  * Track a transaction from an incoming event
  */
@@ -363,36 +415,20 @@ export function trackTransactionFromEvent(event) {
     const eventType = event.event_type || '';
     const timestamp = event.timestamp;
 
-    // Determine operation type and status
-    let op = 'other';
-    let isStart = false;
-    let isEnd = false;
-    let status = null;
-
-    if (eventType.startsWith('put_')) {
-        op = 'put';
-        if (eventType === 'put_request') isStart = true;
-        else if (eventType === 'put_success') { isEnd = true; status = 'success'; }
-    } else if (eventType.startsWith('get_')) {
-        op = 'get';
-        if (eventType === 'get_request') isStart = true;
-        else if (eventType === 'get_success') { isEnd = true; status = 'success'; }
-        else if (eventType === 'get_not_found') { isEnd = true; status = 'not_found'; }
-    } else if (eventType.startsWith('update_')) {
-        op = 'update';
-        if (eventType === 'update_request') isStart = true;
-        else if (eventType === 'update_success') { isEnd = true; status = 'success'; }
-    } else if (eventType.startsWith('subscribe')) {
-        op = 'subscribe';
-        if (eventType === 'subscribe_request') isStart = true;
-        else if (eventType === 'subscribed') { isEnd = true; status = 'success'; }
-    } else if (eventType.includes('connect')) {
-        op = 'connect';
-        if (eventType === 'connect_request_sent') isStart = true;
-        else if (eventType === 'connect_connected') { isEnd = true; status = 'success'; }
-    } else if (eventType === 'disconnect') {
-        op = 'disconnect';
-        isStart = true; isEnd = true; status = 'complete';
+    // Determine operation type, shape and (only when genuinely measured) outcome.
+    let { op, role } = classifyTxEvent(eventType);
+    const isStart = role === 'start';
+    let isEnd = role === 'terminal';
+    let outcome = null;
+    if (isEnd) {
+        if (eventType === 'get_terminal') {
+            // The outcome rides in the event body. Without it nothing has been
+            // measured, so refuse to claim a result.
+            outcome = event.outcome ?? null;
+            if (outcome === null) isEnd = false;
+        } else {
+            outcome = TX_TERMINAL_EVENTS[eventType][1];
+        }
     }
 
     // Check if transaction already exists
@@ -408,12 +444,16 @@ export function trackTransactionFromEvent(event) {
         });
         tx.event_count = tx.events.length;
 
-        // Update end time and status
+        // Update end time, shape and outcome
         if (timestamp > tx.end_ns) {
             tx.end_ns = timestamp;
         }
-        if (isEnd && status) {
-            tx.status = status;
+        if (isStart && tx.tx_shape === 'partial') {
+            tx.tx_shape = 'open';
+        }
+        if (isEnd) {
+            tx.tx_shape = 'settled';
+            tx.outcome = outcome;
             tx.duration_ms = (tx.end_ns - tx.start_ns) / 1_000_000;
         }
     } else {
@@ -426,7 +466,10 @@ export function trackTransactionFromEvent(event) {
             start_ns: timestamp,
             end_ns: timestamp,
             duration_ms: null,
-            status: (isStart && !isEnd) ? 'pending' : (status || 'complete'),
+            // 'partial' is the honest default: an event for this transaction,
+            // but neither its start nor a terminal, so its result is unknown.
+            tx_shape: isEnd ? 'settled' : (isStart ? 'open' : 'partial'),
+            outcome: isEnd ? outcome : null,
             event_count: 1,
             events: [{
                 event_type: eventType,

--- a/js/metrics.js
+++ b/js/metrics.js
@@ -79,13 +79,18 @@ export function initMetricsChart(container) {
 
     const labels = series.map(p => new Date(p.t / 1_000_000));
 
-    // Raw rates for tooltips
+    // Raw rates for tooltips.
+    // get_rate is the CLIENT-FACING direct GET success rate, measured from
+    // get_terminal. It used to be derived from the per-hop get_success /
+    // get_not_found counts, which understated it by ~600x (issue #15).
     const rawGet = series.map(p => p.get_rate);
+    const rawGetSub = series.map(p => p.get_sub_rate);
     const rawPut = series.map(p => p.put_rate);
     const rawUpd = series.map(p => p.upd_rate);
 
     // EMA-smoothed rates for display
     const smoothGet = ema(rawGet);
+    const smoothGetSub = ema(rawGetSub);
     const smoothPut = ema(rawPut);
     const smoothUpd = ema(rawUpd);
 
@@ -112,6 +117,24 @@ export function initMetricsChart(container) {
                     yAxisID: 'y',
                     spanGaps: false,
                     order: 2,
+                },
+                {
+                    // Sub-operation GETs fail far more often than direct ones
+                    // (14-40% success vs ~90%). The old per-hop signal hid this
+                    // entirely, so the 2026-07-26 regression was missed.
+                    label: 'GET (sub-op)',
+                    data: smoothGetSub,
+                    borderColor: C.get,
+                    borderDash: [4, 3],
+                    borderWidth: 1.5,
+                    pointRadius: 0,
+                    pointHoverRadius: 4,
+                    pointHitRadius: 12,
+                    tension: 0.35,
+                    fill: false,
+                    yAxisID: 'y',
+                    spanGaps: false,
+                    order: 1,
                 },
                 {
                     label: 'PUT',
@@ -194,6 +217,7 @@ export function initMetricsChart(container) {
                             const lbl = item.dataset.label;
                             let raw, count;
                             if (lbl === 'GET') { raw = rawGet[idx]; count = s.get_n; }
+                            else if (lbl === 'GET (sub-op)') { raw = rawGetSub[idx]; count = s.get_sub_n; }
                             else if (lbl === 'PUT') { raw = rawPut[idx]; count = s.put_n; }
                             else if (lbl === 'UPDATE') { raw = rawUpd[idx]; count = s.upd_n; }
                             if (raw == null) return ` ${lbl}: insufficient data`;
@@ -246,6 +270,7 @@ export function initMetricsChart(container) {
 
     // Store raw data on chart for updates
     chart._rawGet = rawGet;
+    chart._rawGetSub = rawGetSub;
     chart._rawPut = rawPut;
     chart._rawUpd = rawUpd;
     chart._series = series;
@@ -261,15 +286,26 @@ export function updateMetricsChart() {
     const labels = series.map(p => new Date(p.t / 1_000_000));
 
     const rawGet = series.map(p => p.get_rate);
+    const rawGetSub = series.map(p => p.get_sub_rate);
     const rawPut = series.map(p => p.put_rate);
     const rawUpd = series.map(p => p.upd_rate);
 
     chart.data.labels = labels;
-    chart.data.datasets[0].data = ema(rawGet);
-    chart.data.datasets[1].data = ema(rawPut);
-    chart.data.datasets[2].data = ema(rawUpd);
+    // Match datasets by label rather than position: this list has been indexed
+    // positionally before, so inserting a series silently fed one line another
+    // line's data.
+    const byLabel = {
+        'GET': rawGet,
+        'GET (sub-op)': rawGetSub,
+        'PUT': rawPut,
+        'UPDATE': rawUpd,
+    };
+    for (const ds of chart.data.datasets) {
+        if (byLabel[ds.label]) ds.data = ema(byLabel[ds.label]);
+    }
 
     chart._rawGet = rawGet;
+    chart._rawGetSub = rawGetSub;
     chart._rawPut = rawPut;
     chart._rawUpd = rawUpd;
     chart._series = series;

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+orjson
+uvloop
+websockets

--- a/telemetry_db.py
+++ b/telemetry_db.py
@@ -221,24 +221,33 @@ class TelemetryDB:
         self.conn.executescript(SCHEMA_TABLES)
         self._migrate()
 
+    # Bumped whenever SCHEMA_TABLES changes in a way an existing database has
+    # to be brought forward to. Stored in PRAGMA user_version.
+    SCHEMA_VERSION = 1
+
     def _migrate(self):
         """Bring an existing database up to the current schema.
 
         CREATE TABLE IF NOT EXISTS silently leaves an older table alone, so
-        column changes need doing explicitly. Both ALTER statements below are
+        column changes need doing explicitly. The ALTER statements below are
         metadata-only in SQLite (>= 3.25 for RENAME COLUMN), so they are
         instant even on a 100+ GB database.
+
+        Gated on PRAGMA user_version so a restart costs one integer read: the
+        legacy rewrite below scans `transactions`, which has no index on the
+        old column and holds millions of rows.
         """
+        version = self.conn.execute("PRAGMA user_version").fetchone()[0]
+        if version >= self.SCHEMA_VERSION:
+            return
+
         cols = {row[1] for row in self.conn.execute("PRAGMA table_info(transactions)")}
-        if not cols:
-            return  # table absent entirely; executescript above will have made it
 
         # issue #15: `status` conflated "we saw a terminal" with "we saw
         # anything at all". Split into tx_shape (structure) + outcome (result).
         if "status" in cols and "tx_shape" not in cols:
             self.conn.execute(
                 "ALTER TABLE transactions RENAME COLUMN status TO tx_shape")
-            cols.add("tx_shape")
         if "outcome" not in cols:
             self.conn.execute("ALTER TABLE transactions ADD COLUMN outcome TEXT")
 
@@ -246,26 +255,23 @@ class TelemetryDB:
         # vocabularies. 'success'/'not_found' were genuine measured terminals.
         # 'complete' was the fallback and is NOT evidence of a terminal, so it
         # degrades to 'partial' — we truly do not know what happened.
-        legacy = self.conn.execute(
-            "SELECT COUNT(*) FROM transactions "
-            "WHERE tx_shape IN ('pending', 'complete', 'success', 'not_found')"
-        ).fetchone()[0]
-        if legacy:
-            t0 = time.time()
-            self.conn.execute("""
-                UPDATE transactions
-                   SET outcome = CASE WHEN tx_shape IN ('success', 'not_found')
-                                      THEN tx_shape ELSE outcome END,
-                       tx_shape = CASE tx_shape
-                                      WHEN 'pending' THEN 'open'
-                                      WHEN 'success' THEN 'settled'
-                                      WHEN 'not_found' THEN 'settled'
-                                      ELSE 'partial'
-                                  END
-                 WHERE tx_shape IN ('pending', 'complete', 'success', 'not_found')
-            """)
-            print(f"[db] migrated {legacy:,} legacy transaction rows to "
+        t0 = time.time()
+        cur = self.conn.execute("""
+            UPDATE transactions
+               SET outcome = CASE WHEN tx_shape IN ('success', 'not_found')
+                                  THEN tx_shape ELSE outcome END,
+                   tx_shape = CASE tx_shape
+                                  WHEN 'pending' THEN 'open'
+                                  WHEN 'success' THEN 'settled'
+                                  WHEN 'not_found' THEN 'settled'
+                                  ELSE 'partial'
+                              END
+             WHERE tx_shape IN ('pending', 'complete', 'success', 'not_found')
+        """)
+        if cur.rowcount > 0:
+            print(f"[db] migrated {cur.rowcount:,} legacy transaction rows to "
                   f"tx_shape/outcome in {time.time() - t0:.1f}s", flush=True)
+        self.conn.execute(f"PRAGMA user_version = {self.SCHEMA_VERSION}")
 
     def ensure_indexes(self):
         """Create all indexes. Fast if they already exist, slow for new indexes

--- a/telemetry_db.py
+++ b/telemetry_db.py
@@ -57,6 +57,18 @@ CREATE TABLE IF NOT EXISTS events (
 );
 
 -- Transactions: replaces transactions dict
+--
+-- tx_shape describes the SHAPE of what we observed, never the result:
+--   'open'    -- a genuine start event was seen, no terminal yet
+--   'settled' -- a genuine terminal event was seen; `outcome` says which
+--   'partial' -- events seen, but neither a start nor a terminal. Propagation
+--                events (update_broadcast_received and friends) land here.
+-- `outcome` is the MEASURED result and is NULL unless tx_shape='settled'.
+-- Success rates must be computed over `outcome`, which is NULL exactly when
+-- nothing was measured, so the wrong query returns no rows rather than a
+-- confident wrong number. This column pair replaced a single `status` column
+-- whose 'complete' value was a fallback for "first event wasn't a start" —
+-- see issue #15.
 CREATE TABLE IF NOT EXISTS transactions (
     tx_id TEXT PRIMARY KEY,
     op TEXT NOT NULL,
@@ -64,9 +76,30 @@ CREATE TABLE IF NOT EXISTS transactions (
     contract_short TEXT,
     start_ns INTEGER NOT NULL,
     end_ns INTEGER,
-    status TEXT DEFAULT 'pending',
+    tx_shape TEXT DEFAULT 'partial',
+    outcome TEXT,
     duration_ms REAL,
     event_count INTEGER DEFAULT 0
+);
+
+-- Client-facing GET outcomes, projected out of the `get_terminal` event.
+--
+-- This is the ONLY event that reports the outcome a GET client actually saw.
+-- get_request/get_success/get_not_found are emitted per HOP, so their ratio
+-- tracks route length, not user-visible success. Kept as its own small table
+-- (~200k rows/day) so GET health can be aggregated without either scanning the
+-- multi-hundred-GB events table or adding an event_type index to it.
+CREATE TABLE IF NOT EXISTS get_terminals (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    timestamp_ns INTEGER NOT NULL,
+    tx_id TEXT,
+    peer_id TEXT,
+    contract_key TEXT,
+    outcome TEXT NOT NULL,       -- success | not_found | timeout_exhausted | ...
+    is_sub_op INTEGER NOT NULL,  -- 0 = client-issued GET, 1 = sub-operation
+    attempts INTEGER,
+    hop_count INTEGER,
+    elapsed_ms REAL
 );
 
 -- Transaction events: individual events within a transaction
@@ -146,6 +179,7 @@ SCHEMA_INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_txe_txid ON tx_events(tx_id)",
     "CREATE INDEX IF NOT EXISTS idx_txe_type_ts ON tx_events(event_type, timestamp_ns)",
     "CREATE INDEX IF NOT EXISTS idx_txe_peer_ts ON tx_events(peer_id, event_type, timestamp_ns)",
+    "CREATE INDEX IF NOT EXISTS idx_getterm_ts ON get_terminals(timestamp_ns)",
     "CREATE INDEX IF NOT EXISTS idx_flows_ts ON flows(timestamp_ns)",
     "CREATE INDEX IF NOT EXISTS idx_flows_tx ON flows(tx_id) WHERE tx_id IS NOT NULL",
     "CREATE INDEX IF NOT EXISTS idx_flows_type_ts ON flows(event_type, timestamp_ns)",
@@ -164,6 +198,7 @@ class TelemetryDB:
         self._tx_buf = {}  # tx_id -> tx tuple (batched upserts)
         self._txe_buf = []  # (tx_id, timestamp_ns, event_type, peer_id)
         self._flow_buf = []
+        self._getterm_buf = []  # client-facing GET outcomes
         self._FLUSH_SIZE = 200
         self._enabled = True  # set to False on persistent errors to degrade gracefully
 
@@ -184,6 +219,53 @@ class TelemetryDB:
         self.conn.execute("PRAGMA temp_store=MEMORY")
         # Only create tables synchronously — indexes are deferred
         self.conn.executescript(SCHEMA_TABLES)
+        self._migrate()
+
+    def _migrate(self):
+        """Bring an existing database up to the current schema.
+
+        CREATE TABLE IF NOT EXISTS silently leaves an older table alone, so
+        column changes need doing explicitly. Both ALTER statements below are
+        metadata-only in SQLite (>= 3.25 for RENAME COLUMN), so they are
+        instant even on a 100+ GB database.
+        """
+        cols = {row[1] for row in self.conn.execute("PRAGMA table_info(transactions)")}
+        if not cols:
+            return  # table absent entirely; executescript above will have made it
+
+        # issue #15: `status` conflated "we saw a terminal" with "we saw
+        # anything at all". Split into tx_shape (structure) + outcome (result).
+        if "status" in cols and "tx_shape" not in cols:
+            self.conn.execute(
+                "ALTER TABLE transactions RENAME COLUMN status TO tx_shape")
+            cols.add("tx_shape")
+        if "outcome" not in cols:
+            self.conn.execute("ALTER TABLE transactions ADD COLUMN outcome TEXT")
+
+        # Rewrite legacy values so the retention window isn't a mix of two
+        # vocabularies. 'success'/'not_found' were genuine measured terminals.
+        # 'complete' was the fallback and is NOT evidence of a terminal, so it
+        # degrades to 'partial' — we truly do not know what happened.
+        legacy = self.conn.execute(
+            "SELECT COUNT(*) FROM transactions "
+            "WHERE tx_shape IN ('pending', 'complete', 'success', 'not_found')"
+        ).fetchone()[0]
+        if legacy:
+            t0 = time.time()
+            self.conn.execute("""
+                UPDATE transactions
+                   SET outcome = CASE WHEN tx_shape IN ('success', 'not_found')
+                                      THEN tx_shape ELSE outcome END,
+                       tx_shape = CASE tx_shape
+                                      WHEN 'pending' THEN 'open'
+                                      WHEN 'success' THEN 'settled'
+                                      WHEN 'not_found' THEN 'settled'
+                                      ELSE 'partial'
+                                  END
+                 WHERE tx_shape IN ('pending', 'complete', 'success', 'not_found')
+            """)
+            print(f"[db] migrated {legacy:,} legacy transaction rows to "
+                  f"tx_shape/outcome in {time.time() - t0:.1f}s", flush=True)
 
     def ensure_indexes(self):
         """Create all indexes. Fast if they already exist, slow for new indexes
@@ -223,14 +305,31 @@ class TelemetryDB:
             self._try_flush()
 
     def upsert_transaction(self, tx_id, op, contract_key, contract_short,
-                           start_ns, end_ns, status, duration_ms, event_count):
-        """Buffer a transaction upsert."""
+                           start_ns, end_ns, tx_shape, outcome, duration_ms,
+                           event_count):
+        """Buffer a transaction upsert.
+
+        `tx_shape` is structural ('open'/'settled'/'partial'); `outcome` is the
+        measured result and must be None unless tx_shape == 'settled'.
+        """
         if not self._enabled:
             return
         self._tx_buf[tx_id] = (
             tx_id, op, contract_key, contract_short,
-            start_ns, end_ns, status, duration_ms, event_count
+            start_ns, end_ns, tx_shape, outcome, duration_ms, event_count
         )
+
+    def insert_get_terminal(self, timestamp_ns, tx_id, peer_id, contract_key,
+                            outcome, is_sub_op, attempts, hop_count, elapsed_ms):
+        """Buffer a client-facing GET outcome for the get_terminals table."""
+        if not self._enabled:
+            return
+        self._getterm_buf.append((
+            timestamp_ns, tx_id, peer_id, contract_key, outcome,
+            1 if is_sub_op else 0, attempts, hop_count, elapsed_ms,
+        ))
+        if len(self._getterm_buf) >= self._FLUSH_SIZE:
+            self._try_flush()
 
     def insert_tx_event(self, tx_id, timestamp_ns, event_type, peer_id):
         """Buffer a transaction event."""
@@ -289,10 +388,12 @@ class TelemetryDB:
             self._tx_buf.clear()
             self._txe_buf.clear()
             self._flow_buf.clear()
+            self._getterm_buf.clear()
 
     def flush(self):
         """Flush all buffered writes to DB in a single transaction."""
-        if not self._event_buf and not self._tx_buf and not self._txe_buf and not self._flow_buf:
+        if (not self._event_buf and not self._tx_buf and not self._txe_buf
+                and not self._flow_buf and not self._getterm_buf):
             return
 
         self.conn.execute("BEGIN")
@@ -308,11 +409,21 @@ class TelemetryDB:
             if self._tx_buf:
                 self.conn.executemany(
                     "INSERT OR REPLACE INTO transactions "
-                    "(tx_id, op, contract_key, contract_short, start_ns, end_ns, status, duration_ms, event_count) "
-                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    "(tx_id, op, contract_key, contract_short, start_ns, end_ns, "
+                    "tx_shape, outcome, duration_ms, event_count) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                     list(self._tx_buf.values()),
                 )
                 self._tx_buf.clear()
+
+            if self._getterm_buf:
+                self.conn.executemany(
+                    "INSERT INTO get_terminals (timestamp_ns, tx_id, peer_id, "
+                    "contract_key, outcome, is_sub_op, attempts, hop_count, elapsed_ms) "
+                    "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                    self._getterm_buf,
+                )
+                self._getterm_buf.clear()
 
             if self._txe_buf:
                 self.conn.executemany(
@@ -423,7 +534,7 @@ class TelemetryDB:
             placeholders = ",".join("?" for _ in ops)
             cur = self.conn.execute(
                 f"SELECT t.tx_id, t.op, t.contract_key, t.contract_short, t.start_ns, "
-                f"t.end_ns, t.status, t.duration_ms, t.event_count "
+                f"t.end_ns, t.tx_shape, t.duration_ms, t.event_count, t.outcome "
                 f"FROM transactions t WHERE t.op IN ({placeholders}) "
                 f"ORDER BY t.start_ns DESC LIMIT ?",
                 (*ops, limit),
@@ -431,7 +542,7 @@ class TelemetryDB:
         else:
             cur = self.conn.execute(
                 "SELECT tx_id, op, contract_key, contract_short, start_ns, end_ns, "
-                "status, duration_ms, event_count "
+                "tx_shape, duration_ms, event_count, outcome "
                 "FROM transactions ORDER BY start_ns DESC LIMIT ?",
                 (limit,),
             )
@@ -466,11 +577,27 @@ class TelemetryDB:
                 "start_ns": row[4],
                 "end_ns": row[5] or row[4],
                 "duration_ms": row[7],
-                "status": row[6],
+                "tx_shape": row[6],
+                "outcome": row[9],
                 "event_count": len(events),
                 "events": events,
             })
         return result
+
+    def get_terminal_buckets(self, since_ns, bucket_ns):
+        """Aggregate client-facing GET outcomes into time buckets.
+
+        Returns rows of (bucket_ts, outcome, is_sub_op, count, median elapsed_ms).
+        Reads the small get_terminals projection rather than the events table,
+        which has no event_type index and is hundreds of GB.
+        """
+        return self.conn.execute(
+            f"SELECT (timestamp_ns / {int(bucket_ns)}) * {int(bucket_ns)} AS bucket, "
+            "outcome, is_sub_op, COUNT(*), AVG(elapsed_ms) "
+            "FROM get_terminals WHERE timestamp_ns > ? "
+            "GROUP BY bucket, outcome, is_sub_op ORDER BY bucket",
+            (since_ns,),
+        ).fetchall()
 
     def get_events_for_range(self, start_ns, end_ns, contract_key=None, peer_id=None):
         """Get events for particle animation, with per-type budgets.
@@ -1042,10 +1169,10 @@ class TelemetryDB:
                 deleted = 0
                 self.conn.execute("BEGIN")
                 try:
-                    # events/flows both carry an index on timestamp_ns, so the
-                    # subquery seeks straight to the old rows and the outer
-                    # DELETE removes them by primary key.
-                    for table in ("events", "flows"):
+                    # events/flows/get_terminals all carry an index on
+                    # timestamp_ns, so the subquery seeks straight to the old
+                    # rows and the outer DELETE removes them by primary key.
+                    for table in ("events", "flows", "get_terminals"):
                         cur = self.conn.execute(
                             f"DELETE FROM {table} WHERE id IN "
                             f"(SELECT id FROM {table} WHERE timestamp_ns < ? LIMIT ?)",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,61 @@
+"""Shared fixtures.
+
+The dashboard keeps its counters in module-level globals, so every test has to
+start from a clean slate and against a throwaway database.
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+
+@pytest.fixture
+def srv(tmp_path):
+    """ws_server with all mutable global state reset and a temp DB attached."""
+    import ws_server
+    from telemetry_db import TelemetryDB
+
+    ws_server.transactions.clear()
+    ws_server.transaction_order.clear()
+    ws_server.metrics_buckets.clear()
+    ws_server._current_bucket = None
+    ws_server.pending_ops.clear()
+    ws_server.event_history.clear()
+    ws_server.peers.clear()
+
+    ws_server.op_stats["put"].update(requests=0, successes=0, latencies=[])
+    ws_server.op_stats["get"].update(
+        hop_requests=0, hop_not_found=0,
+        term_direct={"success": 0, "not_found": 0, "other": 0},
+        term_sub_op={"success": 0, "not_found": 0, "other": 0},
+        latencies=[],
+    )
+    ws_server.op_stats["update"].update(requests=0, successes=0, broadcasts=0, latencies=[])
+    ws_server.op_stats["subscribe"].update(requests=0, successes=0, not_found=0, timeouts=0)
+
+    old_db = ws_server.db
+    db = TelemetryDB(str(tmp_path / "t.db"))
+    db.open()
+    ws_server.db = db
+    try:
+        yield ws_server
+    finally:
+        db.close()
+        ws_server.db = old_db
+
+
+def make_record(event_type, ts, tx_id=None, peer="8.8.8.8", **body_fields):
+    """Build an OTLP-shaped record the way a real peer reports one."""
+    import orjson
+
+    body = {"type": event_type, "this_peer": f"pk@{peer}:31337 (@0.5)"}
+    if tx_id:
+        body["id"] = tx_id
+    body.update(body_fields)
+    return {
+        "timeUnixNano": str(ts),
+        "attributes": [{"key": "event_type", "value": {"stringValue": event_type}}],
+        "body": {"stringValue": orjson.dumps(body).decode()},
+    }

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -1,0 +1,155 @@
+"""Schema migration and get_terminals persistence (issue #15)."""
+import sqlite3
+import time
+
+from telemetry_db import TelemetryDB
+
+
+def columns(conn, table):
+    return {r[1] for r in conn.execute(f"PRAGMA table_info({table})")}
+
+
+class TestMigrationFromTheOldStatusColumn:
+    def make_legacy_db(self, path):
+        conn = sqlite3.connect(path)
+        conn.executescript("""
+            CREATE TABLE transactions (
+                tx_id TEXT PRIMARY KEY, op TEXT NOT NULL, contract_key TEXT,
+                contract_short TEXT, start_ns INTEGER NOT NULL, end_ns INTEGER,
+                status TEXT DEFAULT 'pending', duration_ms REAL,
+                event_count INTEGER DEFAULT 0
+            );
+        """)
+        rows = [
+            ("t1", "update", "complete"),   # phantom: propagation event
+            ("t2", "subscribe", "pending"),  # never settled, wrong terminal name
+            ("t3", "get", "success"),        # genuinely measured
+            ("t4", "get", "not_found"),      # genuinely measured
+        ]
+        conn.executemany(
+            "INSERT INTO transactions (tx_id, op, start_ns, status) VALUES (?, ?, 1, ?)",
+            rows)
+        conn.commit()
+        conn.close()
+
+    def test_status_is_renamed_and_outcome_added(self, tmp_path):
+        p = str(tmp_path / "legacy.db")
+        self.make_legacy_db(p)
+        db = TelemetryDB(p)
+        db.open()
+        try:
+            cols = columns(db.conn, "transactions")
+            assert "status" not in cols, "the misleading column name must be gone"
+            assert {"tx_shape", "outcome"} <= cols
+        finally:
+            db.close()
+
+    def test_legacy_values_are_reinterpreted_honestly(self, tmp_path):
+        p = str(tmp_path / "legacy.db")
+        self.make_legacy_db(p)
+        db = TelemetryDB(p)
+        db.open()
+        try:
+            got = dict(
+                (r[0], (r[1], r[2]))
+                for r in db.conn.execute("SELECT tx_id, tx_shape, outcome FROM transactions")
+            )
+        finally:
+            db.close()
+        # 'complete' was never evidence of a terminal, so it degrades to partial
+        # rather than being promoted to a settled result.
+        assert got["t1"] == ("partial", None)
+        assert got["t2"] == ("open", None)
+        assert got["t3"] == ("settled", "success")
+        assert got["t4"] == ("settled", "not_found")
+
+    def test_migration_is_idempotent(self, tmp_path):
+        p = str(tmp_path / "legacy.db")
+        self.make_legacy_db(p)
+        for _ in range(3):
+            db = TelemetryDB(p)
+            db.open()
+            db.close()
+        db = TelemetryDB(p)
+        db.open()
+        try:
+            assert columns(db.conn, "transactions") >= {"tx_shape", "outcome"}
+            n = db.conn.execute(
+                "SELECT COUNT(*) FROM transactions WHERE tx_shape IN "
+                "('pending','complete','success','not_found')").fetchone()[0]
+            assert n == 0
+        finally:
+            db.close()
+
+    def test_fresh_database_has_the_new_schema(self, tmp_path):
+        db = TelemetryDB(str(tmp_path / "fresh.db"))
+        db.open()
+        try:
+            cols = columns(db.conn, "transactions")
+            assert "status" not in cols
+            assert {"tx_shape", "outcome"} <= cols
+            assert "get_terminals" in {
+                r[0] for r in db.conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type='table'")
+            }
+        finally:
+            db.close()
+
+
+class TestGetTerminalsTable:
+    def test_roundtrip_and_bucket_aggregation(self, tmp_path):
+        db = TelemetryDB(str(tmp_path / "t.db"))
+        db.open()
+        try:
+            bucket = 4 * 3600 * 1_000_000_000
+            base = (time.time_ns() // bucket) * bucket + 1_000_000
+            for i in range(7):
+                db.insert_get_terminal(base + i, f"tx{i}", "peer-a", "ck",
+                                       "success", False, 0, 3, 12.0)
+            for i in range(3):
+                db.insert_get_terminal(base + 100 + i, f"sx{i}", "peer-a", "ck",
+                                       "timeout_exhausted", True, 1, 5, 900.0)
+            db.flush()
+
+            rows = db.get_terminal_buckets(base - bucket, bucket)
+            agg = {(r[1], r[2]): r[3] for r in rows}
+            assert agg[("success", 0)] == 7
+            assert agg[("timeout_exhausted", 1)] == 3
+            assert len({r[0] for r in rows}) == 1, "all samples share one bucket"
+        finally:
+            db.close()
+
+    def test_pruning_removes_expired_rows(self, tmp_path):
+        db = TelemetryDB(str(tmp_path / "t.db"))
+        db.open()
+        try:
+            now = time.time_ns()
+            old = now - 48 * 3600 * 1_000_000_000
+            db.insert_get_terminal(old, "old", "p", "c", "success", False, 0, 1, 1.0)
+            db.insert_get_terminal(now, "new", "p", "c", "success", False, 0, 1, 1.0)
+            db.flush()
+            db.prune(retention_ns=24 * 3600 * 1_000_000_000)
+            left = [r[0] for r in db.conn.execute("SELECT tx_id FROM get_terminals")]
+            assert left == ["new"], "get_terminals must not grow without bound"
+        finally:
+            db.close()
+
+
+class TestTransactionRoundTrip:
+    def test_shape_and_outcome_survive_a_write_and_read(self, tmp_path):
+        db = TelemetryDB(str(tmp_path / "t.db"))
+        db.open()
+        try:
+            db.upsert_transaction("tx1", "get", "ck", "ck...", 1, 2,
+                                  "settled", "success", 1.0, 2)
+            db.upsert_transaction("tx2", "update", None, None, 1, 2,
+                                  "partial", None, None, 1)
+            db.flush()
+            got = {t["tx_id"]: t for t in db.get_recent_transactions(limit=10)}
+            assert got["tx1"]["tx_shape"] == "settled"
+            assert got["tx1"]["outcome"] == "success"
+            assert got["tx2"]["tx_shape"] == "partial"
+            assert got["tx2"]["outcome"] is None
+            assert "status" not in got["tx1"]
+        finally:
+            db.close()

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -63,6 +63,38 @@ class TestMigrationFromTheOldStatusColumn:
         assert got["t3"] == ("settled", "success")
         assert got["t4"] == ("settled", "not_found")
 
+    def test_migration_runs_once_and_is_recorded(self, tmp_path):
+        """The legacy rewrite scans a table with millions of rows, so it must
+        not run again on every restart."""
+        p = str(tmp_path / "legacy.db")
+        self.make_legacy_db(p)
+        db = TelemetryDB(p)
+        db.open()
+        try:
+            assert db.conn.execute("PRAGMA user_version").fetchone()[0] == \
+                TelemetryDB.SCHEMA_VERSION
+        finally:
+            db.close()
+
+        # Plant a value the migration WOULD rewrite. If it survives the next
+        # open, the rewrite genuinely did not run again. (A sentinel the
+        # migration ignores would survive either way and prove nothing.)
+        db = TelemetryDB(p)
+        db.open()
+        try:
+            db.conn.execute(
+                "UPDATE transactions SET tx_shape = 'complete' WHERE tx_id = 't1'")
+        finally:
+            db.close()
+        db = TelemetryDB(p)
+        db.open()
+        try:
+            shape = db.conn.execute(
+                "SELECT tx_shape FROM transactions WHERE tx_id='t1'").fetchone()[0]
+            assert shape == "complete", "migration re-ran after it was recorded"
+        finally:
+            db.close()
+
     def test_migration_is_idempotent(self, tmp_path):
         p = str(tmp_path / "legacy.db")
         self.make_legacy_db(p)

--- a/tests/test_get_health_metrics.py
+++ b/tests/test_get_health_metrics.py
@@ -1,0 +1,193 @@
+"""Regression tests for issue #15 — GET health must come from get_terminal.
+
+`get_request` and `get_not_found` are emitted once per HOP, so their ratio
+tracks route length rather than user-visible success. Deriving the Performance
+chart's GET line from them understated success by roughly 600x during the
+2026-07-26 growth surge: the chart read 0.05-0.24% while the client-facing rate
+measured from get_terminal was 86.8-92.2%.
+"""
+import time
+
+from conftest import make_record
+
+
+def feed(srv, event_type, ts, tx_id=None, **body):
+    srv.process_record(make_record(event_type, ts, tx_id=tx_id, **body))
+
+
+def series_of(srv):
+    s = srv.get_metrics_timeseries()["series"]
+    assert s, "expected at least one metrics bucket"
+    return s[-1]
+
+
+class TestGetSuccessRateIgnoresPerHopEvents:
+    def test_a_storm_of_hop_404s_does_not_sink_the_success_rate(self, srv):
+        """The exact production shape: ~1000 hop 404s alongside 20 real successes."""
+        t = time.time_ns()
+        for i in range(1000):
+            feed(srv, "get_not_found", t + i, tx_id=f"hop-{i}")
+        for i in range(20):
+            feed(srv, "get_terminal", t + 2000 + i, tx_id=f"cli-{i}",
+                 outcome="success", is_sub_op=False, elapsed_ms=12)
+
+        point = series_of(srv)
+        assert point["get_rate"] == 100.0, (
+            "GET success rate was contaminated by per-hop routing events "
+            f"(got {point['get_rate']}%)"
+        )
+        assert point["get_n"] == 20
+        # The hop volume is still reported, just not as a success signal.
+        assert point["get_hops_n"] == 1000
+
+    def test_rate_tracks_the_terminals_not_the_hops(self, srv):
+        t = time.time_ns()
+        for i in range(500):
+            feed(srv, "get_not_found", t + i, tx_id=f"hop-{i}")
+        for i in range(8):
+            feed(srv, "get_terminal", t + 1000 + i, tx_id=f"ok-{i}",
+                 outcome="success", is_sub_op=False)
+        for i in range(2):
+            feed(srv, "get_terminal", t + 2000 + i, tx_id=f"bad-{i}",
+                 outcome="not_found", is_sub_op=False)
+
+        point = series_of(srv)
+        assert point["get_rate"] == 80.0
+        assert point["get_n"] == 10
+
+    def test_hop_success_events_do_not_inflate_the_denominator(self, srv):
+        t = time.time_ns()
+        for i in range(6):
+            feed(srv, "get_terminal", t + i, tx_id=f"cli-{i}",
+                 outcome="success", is_sub_op=False)
+        for i in range(50):
+            feed(srv, "get_success", t + 1000 + i, tx_id=f"hop-{i}")
+        assert series_of(srv)["get_n"] == 6
+
+
+class TestSubOperationGetsAreVisible:
+    """The regression that the old signal hid: sub-op GETs timing out."""
+
+    def test_sub_op_outcomes_are_reported_separately(self, srv):
+        t = time.time_ns()
+        for i in range(10):
+            feed(srv, "get_terminal", t + i, tx_id=f"d-{i}",
+                 outcome="success", is_sub_op=False)
+        for i in range(8):
+            feed(srv, "get_terminal", t + 100 + i, tx_id=f"s-{i}",
+                 outcome="timeout_exhausted", is_sub_op=True)
+        for i in range(2):
+            feed(srv, "get_terminal", t + 200 + i, tx_id=f"sok-{i}",
+                 outcome="success", is_sub_op=True)
+
+        point = series_of(srv)
+        assert point["get_rate"] == 100.0, "direct GETs were healthy"
+        assert point["get_sub_rate"] == 20.0, "sub-op failures must stay visible"
+        assert point["get_n"] == 10
+        assert point["get_sub_n"] == 10
+
+    def test_sub_op_failures_do_not_drag_down_the_direct_rate(self, srv):
+        t = time.time_ns()
+        for i in range(6):
+            feed(srv, "get_terminal", t + i, tx_id=f"d-{i}",
+                 outcome="success", is_sub_op=False)
+        for i in range(6):
+            feed(srv, "get_terminal", t + 100 + i, tx_id=f"s-{i}",
+                 outcome="timeout_exhausted", is_sub_op=True)
+        assert series_of(srv)["get_rate"] == 100.0
+
+
+class TestOperationStatsPanel:
+    def test_get_success_rate_is_measured_from_terminals(self, srv):
+        t = time.time_ns()
+        for i in range(200):
+            feed(srv, "get_not_found", t + i, tx_id=f"hop-{i}")
+        for i in range(9):
+            feed(srv, "get_terminal", t + 1000 + i, tx_id=f"ok-{i}",
+                 outcome="success", is_sub_op=False)
+        feed(srv, "get_terminal", t + 2000, tx_id="bad", outcome="not_found",
+             is_sub_op=False)
+
+        stats = srv.get_operation_stats()["get"]
+        assert stats["success_rate"] == 90.0
+        assert stats["total"] == 10
+        assert stats["not_found"] == 1
+        # Hop counters survive under names that cannot be read as an outcome.
+        assert stats["hop_not_found"] == 200
+        assert "requests" not in stats
+
+    def test_sub_op_rate_is_exposed(self, srv):
+        t = time.time_ns()
+        for i in range(4):
+            feed(srv, "get_terminal", t + i, tx_id=f"s-{i}",
+                 outcome="timeout_exhausted", is_sub_op=True)
+        feed(srv, "get_terminal", t + 100, tx_id="sok", outcome="success",
+             is_sub_op=True)
+        stats = srv.get_operation_stats()["get"]
+        assert stats["sub_op_total"] == 5
+        assert stats["sub_op_success_rate"] == 20.0
+
+    def test_unknown_outcome_counts_without_inflating_success(self, srv):
+        t = time.time_ns()
+        for i in range(5):
+            feed(srv, "get_terminal", t + i, tx_id=f"w-{i}",
+                 outcome="something_new", is_sub_op=False)
+        stats = srv.get_operation_stats()["get"]
+        assert stats["total"] == 5
+        assert stats["success_rate"] == 0.0
+
+    def test_latency_still_measured_from_request_to_success(self, srv):
+        """get_terminal reports elapsed_ms=0 on 99.5% of successful direct GETs,
+        so it cannot be the latency source even though it is the outcome source.
+        Latency stays on the request->success delta."""
+        t = time.time_ns()
+        for i in range(5):
+            feed(srv, "get_request", t + i * 1_000_000_000, tx_id=f"l-{i}")
+            feed(srv, "get_success", t + i * 1_000_000_000 + 40_000_000, tx_id=f"l-{i}")
+        assert srv.get_operation_stats()["get"]["latency"]["p50"] == 40
+
+    def test_zero_elapsed_terminals_do_not_flatten_the_latency_series(self, srv):
+        """Regression guard for the trap above: a flood of elapsed_ms=0
+        terminals must not drag the reported GET latency to zero."""
+        t = time.time_ns()
+        for i in range(5):
+            feed(srv, "get_request", t + i * 1_000_000_000, tx_id=f"l-{i}")
+            feed(srv, "get_success", t + i * 1_000_000_000 + 40_000_000, tx_id=f"l-{i}")
+        for i in range(500):
+            feed(srv, "get_terminal", t + 10_000_000_000 + i, tx_id=f"z-{i}",
+                 outcome="success", is_sub_op=False, elapsed_ms=0)
+
+        assert srv.get_operation_stats()["get"]["latency"]["p50"] == 40
+        assert series_of(srv)["lat_get"] == 40
+        # ...while the success rate is still measured from those terminals.
+        assert series_of(srv)["get_rate"] == 100.0
+
+
+class TestSubscribeStatsAreNoLongerPinnedAtZero:
+    def test_subscribe_success_is_counted(self, srv):
+        """op_stats and sub_ok both keyed on `subscribed`, which is never
+        emitted, so every subscribe counter read zero."""
+        t = time.time_ns()
+        for i in range(8):
+            feed(srv, "subscribe_request", t + i, tx_id=f"s-{i}")
+        for i in range(6):
+            feed(srv, "subscribe_success", t + 100 + i, tx_id=f"s-{i}")
+        for i in range(2):
+            feed(srv, "subscribe_not_found", t + 200 + i, tx_id=f"s-{6 + i}")
+
+        stats = srv.get_operation_stats()["subscribe"]
+        assert stats["total"] == 8
+        assert stats["success_rate"] == 75.0
+        assert stats["not_found"] == 2
+        assert series_of(srv)["sub_n"] == 8
+        assert series_of(srv)["sub_rate"] == 75.0
+
+    def test_subscribe_timeout_counts_as_a_failure(self, srv):
+        t = time.time_ns()
+        for i in range(5):
+            feed(srv, "subscribe_success", t + i, tx_id=f"s-{i}")
+        for i in range(5):
+            feed(srv, "subscribe_timeout", t + 100 + i, tx_id=f"t-{i}")
+        stats = srv.get_operation_stats()["subscribe"]
+        assert stats["timeouts"] == 5
+        assert stats["success_rate"] == 50.0

--- a/tests/test_get_health_metrics.py
+++ b/tests/test_get_health_metrics.py
@@ -127,6 +127,22 @@ class TestOperationStatsPanel:
         assert stats["sub_op_total"] == 5
         assert stats["sub_op_success_rate"] == 20.0
 
+    def test_a_terminal_with_no_outcome_measures_nothing(self, srv):
+        """Stats and transaction tracking must agree: an event carrying no
+        outcome has measured nothing and must not count as a failure."""
+        t = time.time_ns()
+        for i in range(6):
+            feed(srv, "get_terminal", t + i, tx_id=f"ok-{i}",
+                 outcome="success", is_sub_op=False)
+        for i in range(20):
+            # No `outcome` key at all.
+            feed(srv, "get_terminal", t + 1000 + i, tx_id=f"none-{i}", is_sub_op=False)
+
+        stats = srv.get_operation_stats()["get"]
+        assert stats["total"] == 6, "outcome-less terminals must not be counted"
+        assert stats["success_rate"] == 100.0
+        assert series_of(srv)["get_rate"] == 100.0
+
     def test_unknown_outcome_counts_without_inflating_success(self, srv):
         t = time.time_ns()
         for i in range(5):

--- a/tests/test_metrics_chart_contract.py
+++ b/tests/test_metrics_chart_contract.py
@@ -1,0 +1,69 @@
+"""The Performance chart must plot the series the server actually emits.
+
+js/metrics.js has no build step and no browser test, so a rename on either side
+only shows up as a blank line on the live dashboard.
+"""
+import os
+import re
+import time
+
+import pytest
+
+from conftest import make_record
+
+JS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                  "js", "metrics.js")
+
+
+def js_source():
+    with open(JS, encoding="utf-8") as f:
+        return f.read()
+
+
+def series_keys_read_by_client():
+    """Keys pulled off a series point: `series.map(p => p.foo)` and, inside the
+    tooltip, `s.foo` where `const s = series[idx]`."""
+    src = js_source()
+    keys = set(re.findall(r"p\s*=>\s*p\.([a-z_]+)", src))
+    keys |= set(re.findall(r"\bcount\s*=\s*s\.([a-z_]+)", src))
+    assert keys, "the extraction regex matched nothing — it has drifted"
+    return keys
+
+
+def test_every_series_key_the_chart_reads_is_emitted(srv):
+    t = time.time_ns()
+    for i in range(6):
+        srv.process_record(make_record("get_terminal", t + i, tx_id=f"g-{i}",
+                                       outcome="success", is_sub_op=False))
+    point = srv.get_metrics_timeseries()["series"][-1]
+
+    unknown = series_keys_read_by_client() - set(point) - {"t"}
+    assert not unknown, f"js/metrics.js reads keys the server never sends: {sorted(unknown)}"
+
+
+@pytest.mark.parametrize("key", [
+    "get_rate", "get_sub_rate", "put_rate", "upd_rate",
+    "get_n", "get_sub_n", "put_n", "upd_n",
+])
+def test_chart_keys_are_present(srv, key):
+    t = time.time_ns()
+    srv.process_record(make_record("get_terminal", t, tx_id="g", outcome="success"))
+    assert key in srv.get_metrics_timeseries()["series"][-1]
+
+
+def test_sub_op_line_is_plotted_and_wired_to_its_own_data():
+    src = js_source()
+    assert "'GET (sub-op)'" in src, "the sub-op GET line must be on the chart"
+    assert "rawGetSub" in src
+    # The dataset list is refreshed by label, not index — indexing positionally
+    # fed one line another line's data once a series was inserted.
+    assert "chart.data.datasets[0].data" not in src
+    assert "for (const ds of chart.data.datasets)" in src
+
+
+def test_client_no_longer_reads_a_hop_derived_get_rate():
+    """get_rate must come from the server's terminal-based computation; the
+    client must not be recomputing anything from hop counts."""
+    src = js_source()
+    assert "get_nf" not in src
+    assert "get_ok" not in src

--- a/tests/test_server_client_agreement.py
+++ b/tests/test_server_client_agreement.py
@@ -1,0 +1,93 @@
+"""The server and the browser client must classify transactions identically.
+
+ws_server.py and js/events.js each carry their own copy of the start/terminal
+tables. They are the two halves of the same fix, and a change to one that
+misses the other silently reintroduces the drift issue #15 is about.
+"""
+import ast
+import os
+import re
+
+import pytest
+
+import ws_server
+
+JS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                  "js", "events.js")
+
+
+def js_source():
+    with open(JS, encoding="utf-8") as f:
+        return f.read()
+
+
+def parse_js_object(name):
+    """Pull a `const NAME = { ... };` literal out of js/events.js."""
+    src = js_source()
+    m = re.search(r"const\s+%s\s*=\s*\{(.*?)\n\};" % re.escape(name), src, re.S)
+    assert m, f"{name} not found in js/events.js"
+    body = m.group(1)
+    out = {}
+    for line in body.splitlines():
+        line = line.strip()
+        if not line or line.startswith("//"):
+            continue
+        km = re.match(r"([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(.+?),?$", line)
+        if not km:
+            continue
+        raw = km.group(2).rstrip(",")
+        if raw.startswith("["):
+            out[km.group(1)] = tuple(ast.literal_eval(raw.replace("'", '"')))
+        else:
+            out[km.group(1)] = ast.literal_eval(raw.replace("'", '"'))
+    return out
+
+
+def test_start_events_match():
+    assert parse_js_object("TX_START_EVENTS") == ws_server.TX_START_EVENTS
+
+
+def test_terminal_events_match():
+    js = parse_js_object("TX_TERMINAL_EVENTS")
+    py = {k: tuple(v) for k, v in ws_server.TX_TERMINAL_EVENTS.items()}
+    assert js == py
+
+
+@pytest.mark.parametrize("event_type", [
+    "get_request", "get_success", "get_not_found", "get_terminal",
+    "subscribe_request", "subscribe_success", "subscribe_not_found",
+    "subscribe_timeout", "subscribed",
+    "put_request", "put_success", "update_request", "update_success",
+    "update_broadcast_received", "connect_connected", "disconnect",
+])
+def test_classification_agrees_for_every_event_the_dashboard_sees(event_type):
+    """Cross-check the Python classifier against the JS tables."""
+    op, role = ws_server.classify_tx_event(event_type)
+    js_start = parse_js_object("TX_START_EVENTS")
+    js_terminal = parse_js_object("TX_TERMINAL_EVENTS")
+    if event_type in js_start:
+        assert (op, role) == (js_start[event_type], "start")
+    elif event_type in js_terminal:
+        assert (op, role) == (js_terminal[event_type][0], "terminal")
+    elif event_type == "get_terminal":
+        assert (op, role) == ("get", "terminal")
+    else:
+        assert role is None
+
+
+class TestTheClientNoLongerCarriesTheOldSemantics:
+    def test_no_complete_fallback_in_the_client(self):
+        src = js_source()
+        assert "status || 'complete'" not in src
+        assert "tx.status" not in src, "client still writes the misleading field"
+
+    def test_client_settles_on_the_real_subscribe_terminals(self):
+        js = parse_js_object("TX_TERMINAL_EVENTS")
+        assert js["subscribe_success"] == ("subscribe", "success")
+        assert js["subscribe_not_found"] == ("subscribe", "not_found")
+        assert js["subscribe_timeout"] == ("subscribe", "timeout")
+
+    def test_client_does_not_settle_on_per_hop_get_events(self):
+        js = parse_js_object("TX_TERMINAL_EVENTS")
+        assert "get_success" not in js
+        assert "get_not_found" not in js

--- a/tests/test_transaction_payloads.py
+++ b/tests/test_transaction_payloads.py
@@ -1,0 +1,99 @@
+"""The three writers of transaction shape must agree.
+
+The dashboard reaches the same `transactions` table by three independent
+paths — the live in-memory tracker, the SQLite history query, and the bulk
+backfill script. The client cannot tell them apart, so a field name or a
+classification that differs between them is a silent break.
+"""
+import time
+
+import pytest
+
+import backfill_db
+import ws_server
+from conftest import make_record
+
+
+class TestBackfillMatchesTheServer:
+    def test_start_events_agree(self):
+        assert backfill_db.TX_START_EVENTS == set(ws_server.TX_START_EVENTS)
+
+    def test_terminal_events_and_outcomes_agree(self):
+        server = {k: v[1] for k, v in ws_server.TX_TERMINAL_EVENTS.items()}
+        assert backfill_db.TX_TERMINAL_EVENTS == server
+
+    def test_backfill_does_not_settle_on_per_hop_get_events(self):
+        """It used to mark get_not_found as 'success' outright."""
+        assert "get_success" not in backfill_db.TX_TERMINAL_EVENTS
+        assert "get_not_found" not in backfill_db.TX_TERMINAL_EVENTS
+
+    def test_backfill_stores_the_client_facing_get_event(self):
+        assert "get_terminal" in backfill_db.HISTORY_EVENT_TYPES
+        assert "subscribe_timeout" in backfill_db.HISTORY_EVENT_TYPES
+
+
+class TestLiveAndHistoryPayloadsAgree:
+    def test_live_list_reports_shape_and_outcome(self, srv):
+        srv.track_transaction("tx1", "get_request", 100, "peer-a")
+        srv.track_transaction("tx1", "get_terminal", 200, "peer-a",
+                              terminal_outcome="success")
+        [tx] = srv.get_transactions_list()
+        assert tx["tx_shape"] == "settled"
+        assert tx["outcome"] == "success"
+        assert "status" not in tx
+
+    def test_live_and_db_paths_expose_the_same_fields(self, srv):
+        srv.track_transaction("tx1", "subscribe_request", 100, "peer-a")
+        srv.track_transaction("tx1", "subscribe_not_found", 200, "peer-a")
+        live = srv.get_transactions_list()[0]
+        srv.db.flush()
+        stored = srv.db.get_recent_transactions(limit=10)[0]
+
+        shared = {"tx_id", "op", "start_ns", "end_ns", "duration_ms",
+                  "tx_shape", "outcome", "event_count", "events"}
+        assert shared <= set(live)
+        assert shared <= set(stored)
+        assert live["tx_shape"] == stored["tx_shape"] == "settled"
+        assert live["outcome"] == stored["outcome"] == "not_found"
+
+    def test_unsettled_transaction_carries_no_outcome_through_either_path(self, srv):
+        srv.track_transaction("tx1", "update_broadcast_received", 100, "peer-a")
+        live = srv.get_transactions_list()[0]
+        srv.db.flush()
+        stored = srv.db.get_recent_transactions(limit=10)[0]
+        assert live["tx_shape"] == stored["tx_shape"] == "partial"
+        assert live["outcome"] is None and stored["outcome"] is None
+
+
+class TestGetTerminalsPersistEndToEnd:
+    def test_process_record_projects_the_outcome_into_its_table(self, srv):
+        t = time.time_ns()
+        srv.process_record(make_record("get_terminal", t, tx_id="tx1",
+                                       outcome="timeout_exhausted", is_sub_op=True,
+                                       attempts=2, hop_count=4, elapsed_ms=310))
+        srv.db.flush()
+        rows = srv.db.conn.execute(
+            "SELECT tx_id, outcome, is_sub_op, attempts, hop_count, elapsed_ms "
+            "FROM get_terminals").fetchall()
+        assert rows == [("tx1", "timeout_exhausted", 1, 2, 4, 310)]
+
+    def test_the_metrics_precompute_reads_them_back(self, srv):
+        t = time.time_ns()
+        for i in range(6):
+            srv.process_record(make_record("get_terminal", t + i, tx_id=f"g-{i}",
+                                           outcome="success", is_sub_op=False))
+        srv.db.flush()
+        # Wipe the in-memory buckets: this is the post-restart path.
+        srv.metrics_buckets.clear()
+        srv._current_bucket = None
+        srv.precompute_metrics_from_db()
+        assert srv.get_metrics_timeseries()["series"][-1]["get_rate"] == 100.0
+
+    @pytest.mark.parametrize("outcome", ["success", "not_found", "timeout_exhausted"])
+    def test_no_row_is_written_without_an_outcome(self, srv, outcome):
+        t = time.time_ns()
+        srv.process_record(make_record("get_terminal", t, tx_id="good", outcome=outcome))
+        srv.process_record(make_record("get_terminal", t + 1, tx_id="bad"))
+        srv.db.flush()
+        stored = [r[0] for r in srv.db.conn.execute("SELECT tx_id FROM get_terminals")]
+        assert stored == ["good"]

--- a/tests/test_transaction_shape.py
+++ b/tests/test_transaction_shape.py
@@ -1,0 +1,139 @@
+"""Regression tests for issue #15 — transaction shape vs measured outcome.
+
+`transactions.status` used to conflate "we saw a terminal event" with "we saw
+any event at all": its 'complete' value was a fallback for any transaction
+whose first observed event was not a start. Propagation events dominate that
+case, so success rates read off the column were confidently wrong.
+"""
+import time
+
+import pytest
+
+
+def track(srv, event_type, tx_id, ts=None, **kw):
+    srv.track_transaction(tx_id, event_type, ts or time.time_ns(), "peer-a", **kw)
+    return srv.transactions[tx_id]
+
+
+class TestPropagationEventsDoNotMintCompletions:
+    """Defect 1: 'complete' was a fallback, not a result."""
+
+    @pytest.mark.parametrize("event_type", [
+        "update_broadcast_received",
+        "update_broadcast_applied",
+        "update_broadcast_emitted",
+    ])
+    def test_propagation_event_alone_is_partial_with_no_outcome(self, srv, event_type):
+        # Before the fix this produced status='complete' — ~29M synthetic
+        # completions over a 48h window.
+        tx = track(srv, event_type, "tx-prop")
+        assert tx["tx_shape"] == "partial"
+        assert tx["outcome"] is None
+
+    def test_a_start_alone_is_open_not_settled(self, srv):
+        tx = track(srv, "get_request", "tx-open")
+        assert tx["tx_shape"] == "open"
+        assert tx["outcome"] is None
+
+    def test_late_start_upgrades_partial_to_open(self, srv):
+        track(srv, "update_broadcast_received", "tx-late", ts=100)
+        tx = track(srv, "update_request", "tx-late", ts=200)
+        assert tx["tx_shape"] == "open"
+
+
+class TestSubscribeReachesATerminal:
+    """Defect 2: the terminal handler keyed on an event core never emits."""
+
+    def test_subscribed_is_not_the_name_core_emits(self, srv):
+        # Guards the root cause: `subscribed` had zero occurrences in the entire
+        # live database, while subscribe_success had 594,480.
+        assert "subscribe_success" in srv.TX_TERMINAL_EVENTS
+        assert "subscribe_not_found" in srv.TX_TERMINAL_EVENTS
+        assert "subscribe_timeout" in srv.TX_TERMINAL_EVENTS
+
+    @pytest.mark.parametrize("event_type,expected", [
+        ("subscribe_success", "success"),
+        ("subscribe_not_found", "not_found"),
+        ("subscribe_timeout", "timeout"),
+        ("subscribed", "success"),  # legacy alias must still settle
+    ])
+    def test_subscribe_settles_with_its_outcome(self, srv, event_type, expected):
+        track(srv, "subscribe_request", "tx-sub", ts=100)
+        tx = track(srv, event_type, "tx-sub", ts=200)
+        assert tx["tx_shape"] == "settled"
+        assert tx["outcome"] == expected
+
+    def test_subscribe_does_not_stay_open_forever(self, srv):
+        # 1,555,103 permanently-pending subscribes were measured on main.
+        track(srv, "subscribe_request", "tx-sub", ts=100)
+        assert srv.transactions["tx-sub"]["tx_shape"] == "open"
+        track(srv, "subscribe_success", "tx-sub", ts=200)
+        assert srv.transactions["tx-sub"]["tx_shape"] == "settled"
+
+
+class TestGetOutcomeComesFromTheClientTerminal:
+    """get_success / get_not_found are per-HOP and must not settle a tx."""
+
+    @pytest.mark.parametrize("hop_event", ["get_success", "get_not_found"])
+    def test_hop_events_do_not_settle_or_claim_an_outcome(self, srv, hop_event):
+        track(srv, "get_request", "tx-get", ts=100)
+        tx = track(srv, hop_event, "tx-get", ts=200)
+        assert tx["tx_shape"] == "open", (
+            "a per-hop event reported a relay's local view as the client's result"
+        )
+        assert tx["outcome"] is None
+
+    @pytest.mark.parametrize("outcome", ["success", "not_found", "timeout_exhausted"])
+    def test_get_terminal_settles_with_the_client_facing_outcome(self, srv, outcome):
+        track(srv, "get_request", "tx-get", ts=100)
+        tx = track(srv, "get_terminal", "tx-get", ts=200, terminal_outcome=outcome)
+        assert tx["tx_shape"] == "settled"
+        assert tx["outcome"] == outcome
+
+    def test_get_terminal_without_an_outcome_measures_nothing(self, srv):
+        track(srv, "get_request", "tx-get", ts=100)
+        tx = track(srv, "get_terminal", "tx-get", ts=200, terminal_outcome=None)
+        assert tx["tx_shape"] == "open"
+        assert tx["outcome"] is None
+
+    def test_client_terminal_wins_over_a_contradicting_hop(self, srv):
+        """A GET that 404s at one relay and succeeds at the client is a success."""
+        track(srv, "get_request", "tx-get", ts=100)
+        track(srv, "get_not_found", "tx-get", ts=150)
+        tx = track(srv, "get_terminal", "tx-get", ts=200, terminal_outcome="success")
+        assert tx["outcome"] == "success"
+
+
+class TestInvariants:
+    def test_outcome_is_set_only_when_settled(self, srv):
+        """The whole point of the split: a result exists only when measured."""
+        stream = [
+            ("get_request", "a"), ("get_not_found", "a"), ("get_success", "a"),
+            ("update_broadcast_received", "b"), ("update_broadcast_applied", "b"),
+            ("subscribe_request", "c"), ("subscribe_not_found", "c"),
+            ("put_request", "d"),
+            ("connect_request_sent", "e"), ("connect_connected", "e"),
+        ]
+        for i, (et, tx_id) in enumerate(stream):
+            track(srv, et, tx_id, ts=100 + i)
+        for tx_id, tx in srv.transactions.items():
+            assert tx["tx_shape"] in ("open", "settled", "partial")
+            if tx["outcome"] is not None:
+                assert tx["tx_shape"] == "settled", f"{tx_id} claims an unmeasured outcome"
+            if tx["tx_shape"] != "settled":
+                assert tx["outcome"] is None, f"{tx_id} has an outcome without a terminal"
+
+    def test_complete_is_no_longer_a_reachable_value(self, srv):
+        """'complete' was the fallback that started all this."""
+        for i, et in enumerate([
+            "update_broadcast_received", "get_request", "get_not_found",
+            "subscribe_request", "subscribe_success",
+            "put_request", "put_success", "seeding_started",
+        ]):
+            # seeding_started is not a tracked op, so it may be skipped —
+            # that is fine, this asserts over whatever was recorded.
+            srv.track_transaction(f"tx-{i}", et, 100 + i, "peer-a")
+        assert srv.transactions, "expected some transactions to be tracked"
+        shapes = {tx["tx_shape"] for tx in srv.transactions.values()}
+        assert "complete" not in shapes
+        assert "pending" not in shapes

--- a/tests/test_transaction_shape.py
+++ b/tests/test_transaction_shape.py
@@ -104,6 +104,24 @@ class TestGetOutcomeComesFromTheClientTerminal:
         assert tx["outcome"] == "success"
 
 
+class TestNoPhantomTransactionGrowth:
+    """The issue is partly about phantom rows, so classification must not start
+    tracking event types that were previously ignored."""
+
+    @pytest.mark.parametrize("event_type", [
+        "unsubscribed", "seeding_started", "seeding_stopped",
+        "peer_startup", "peer_shutdown", "transfer_completed",
+    ])
+    def test_untracked_events_do_not_create_transactions(self, srv, event_type):
+        srv.track_transaction("tx-new", event_type, 100, "peer-a")
+        assert "tx-new" not in srv.transactions
+
+    def test_untracked_events_still_attach_to_an_existing_transaction(self, srv):
+        track(srv, "subscribe_request", "tx-x", ts=100)
+        srv.track_transaction("tx-x", "unsubscribed", 200, "peer-a")
+        assert len(srv.transactions["tx-x"]["events"]) == 2
+
+
 class TestInvariants:
     def test_outcome_is_set_only_when_settled(self, srv):
         """The whole point of the split: a result exists only when measured."""

--- a/ws_server.py
+++ b/ws_server.py
@@ -201,14 +201,14 @@ HISTORY_EVENT_TYPES = {
     "get_request", "get_success", "get_not_found", "get_failure",
     # get_terminal carries the CLIENT-FACING outcome of a GET (success /
     # not_found / timeout_exhausted) plus is_sub_op, attempts, elapsed_ms and
-    # hop_count. Without it the DB cannot answer "are GETs working": the
-    # get_request/get_not_found events are emitted per HOP, so their ratio
-    # tracks route length rather than user-visible success, and
-    # transactions.status is not a measured outcome either (see the comment on
-    # tx status assignment below). Low volume — roughly 900/hour network-wide.
+    # hop_count. It is the sole basis for every GET success rate the dashboard
+    # reports: the get_request/get_not_found events are emitted per HOP, so
+    # their ratio tracks route length rather than user-visible success.
+    # Low volume — roughly 8k/hour network-wide at ~900 peers.
     "get_terminal",
     "update_request", "update_success", "update_failure",
     "subscribe_request", "subscribe_success", "subscribe_not_found",
+    "subscribe_timeout",
     # Update propagation
     "update_broadcast_received", "update_broadcast_applied",
     "update_broadcast_emitted", "broadcast_emitted",
@@ -503,18 +503,32 @@ def get_propagation_data():
 
 
 # Operation statistics
+#
+# GET has two distinct families of counter and they must not be mixed:
+#   hop_requests / hop_not_found   — per-HOP routing events. Their ratio tracks
+#                                    route length, NOT user-visible success.
+#   term_*                         — client-facing outcomes from get_terminal,
+#                                    split by direct vs sub-operation. These are
+#                                    the only ones a success rate may use.
 op_stats = {
     "put": {"requests": 0, "successes": 0, "latencies": []},
-    "get": {"requests": 0, "successes": 0, "not_found": 0, "latencies": []},
+    "get": {
+        "hop_requests": 0, "hop_not_found": 0,
+        "term_direct": {"success": 0, "not_found": 0, "other": 0},
+        "term_sub_op": {"success": 0, "not_found": 0, "other": 0},
+        "latencies": [],
+    },
     "update": {"requests": 0, "successes": 0, "broadcasts": 0, "latencies": []},
-    "subscribe": {"requests": 0, "successes": 0},
+    "subscribe": {"requests": 0, "successes": 0, "not_found": 0, "timeouts": 0},
 }
 
 # ── Time-series metrics (4-hour buckets, kept for 8 days) ──
 METRICS_BUCKET_NS = 4 * 60 * 60 * 1_000_000_000    # 4 hours
 METRICS_MAX_AGE_NS = 8 * 24 * 60 * 60 * 1_000_000_000  # 8 days
 METRICS_MIN_SAMPLES = 5  # Minimum ops in a bucket to compute a meaningful rate
-# Each bucket: {ts, put_req, put_ok, get_req, get_ok, get_nf, upd_req, upd_ok, sub_ok, peers, latencies_put, latencies_get, latencies_upd}
+# Each bucket: {ts, put_req, put_ok, get_req, get_nf (per-HOP volume),
+#               gt_ok/gt_bad + gt_sub_ok/gt_sub_bad (client-facing GET outcomes),
+#               upd_req, upd_ok, sub_ok, sub_bad, peers, lat_put, lat_get, lat_upd}
 metrics_buckets = {}       # bucket_key -> bucket dict (dict for O(1) lookup by timestamp)
 _current_bucket = None     # the bucket we're currently filling
 
@@ -551,9 +565,13 @@ def _get_or_create_bucket(timestamp_ns):
     _current_bucket = {
         "ts": key,
         "put_req": 0, "put_ok": 0,
-        "get_req": 0, "get_ok": 0, "get_nf": 0,
+        # get_req/get_nf are per-HOP counts, kept for routing volume only.
+        "get_req": 0, "get_nf": 0,
+        # Client-facing GET outcomes from get_terminal, split direct vs sub-op.
+        "gt_ok": 0, "gt_bad": 0,
+        "gt_sub_ok": 0, "gt_sub_bad": 0,
         "upd_req": 0, "upd_ok": 0,
-        "sub_ok": 0,
+        "sub_ok": 0, "sub_bad": 0,
         "reporting_peers": set(),
         "lat_put": [], "lat_get": [], "lat_upd": [],
     }
@@ -561,8 +579,13 @@ def _get_or_create_bucket(timestamp_ns):
     return _current_bucket
 
 
-def record_metric(event_type, timestamp_ns, latency_ms=None, peer_id=None):
-    """Record an operation into the current time bucket."""
+def record_metric(event_type, timestamp_ns, latency_ms=None, peer_id=None,
+                  outcome=None, is_sub_op=False):
+    """Record an operation into the current time bucket.
+
+    `outcome`/`is_sub_op` apply to get_terminal, the only GET event that
+    reports what the requesting client actually saw.
+    """
     b = _get_or_create_bucket(timestamp_ns)
     if peer_id:
         b["reporting_peers"].add(peer_id)
@@ -574,20 +597,28 @@ def record_metric(event_type, timestamp_ns, latency_ms=None, peer_id=None):
             b["lat_put"].append(latency_ms)
     elif event_type == "get_request":
         b["get_req"] += 1
-    elif event_type == "get_success":
-        b["get_ok"] += 1
-        if latency_ms is not None:
-            b["lat_get"].append(latency_ms)
     elif event_type == "get_not_found":
         b["get_nf"] += 1
+    elif event_type == "get_success":
+        # Per-hop, so it contributes latency only — never a rate counter.
+        if latency_ms is not None:
+            b["lat_get"].append(latency_ms)
+    elif event_type == "get_terminal":
+        ok = outcome == "success"
+        if is_sub_op:
+            b["gt_sub_ok" if ok else "gt_sub_bad"] += 1
+        else:
+            b["gt_ok" if ok else "gt_bad"] += 1
     elif event_type == "update_request":
         b["upd_req"] += 1
     elif event_type == "update_success":
         b["upd_ok"] += 1
         if latency_ms is not None:
             b["lat_upd"].append(latency_ms)
-    elif event_type == "subscribed":
+    elif event_type == "subscribe_success":
         b["sub_ok"] += 1
+    elif event_type in ("subscribe_not_found", "subscribe_timeout"):
+        b["sub_bad"] += 1
 
 
 def record_version(version_str, timestamp_ns):
@@ -609,11 +640,13 @@ def precompute_metrics_from_db():
     now_ns = int(_time.time() * 1_000_000_000)
     cutoff_ns = now_ns - METRICS_MAX_AGE_NS  # 8 days
 
+    # get_terminal is absent here on purpose: tx_events has no outcome column,
+    # so GET success is precomputed from the get_terminals table below.
     metric_event_types = (
         'put_request', 'put_success',
-        'get_request', 'get_success', 'get_not_found',
+        'get_request', 'get_not_found',
         'update_request', 'update_success',
-        'subscribed',
+        'subscribe_success', 'subscribe_not_found', 'subscribe_timeout',
     )
 
     # Use tx_events (no JSON blob column, much smaller than events table)
@@ -630,15 +663,13 @@ def precompute_metrics_from_db():
         ORDER BY bucket
     """, (cutoff_ns, *metric_event_types)).fetchall()
 
-    if not rows:
-        return
-
     # Map event_type -> bucket field name for bulk updates
     _type_to_field = {
         'put_request': 'put_req', 'put_success': 'put_ok',
-        'get_request': 'get_req', 'get_success': 'get_ok', 'get_not_found': 'get_nf',
+        'get_request': 'get_req', 'get_not_found': 'get_nf',
         'update_request': 'upd_req', 'update_success': 'upd_ok',
-        'subscribed': 'sub_ok',
+        'subscribe_success': 'sub_ok',
+        'subscribe_not_found': 'sub_bad', 'subscribe_timeout': 'sub_bad',
     }
     total_events = 0
     for event_type, bucket_ts, count in rows:
@@ -647,6 +678,24 @@ def precompute_metrics_from_db():
         field = _type_to_field.get(event_type)
         if field:
             b[field] += count
+
+    # Client-facing GET outcomes come from their own table, which stores the
+    # outcome and is_sub_op that tx_events cannot carry.
+    try:
+        for bucket_ts, outcome, is_sub_op, count, _avg_ms in db.get_terminal_buckets(
+                cutoff_ns, METRICS_BUCKET_NS):
+            total_events += count
+            b = _get_or_create_bucket(bucket_ts)
+            ok = outcome == "success"
+            if is_sub_op:
+                b["gt_sub_ok" if ok else "gt_sub_bad"] += count
+            else:
+                b["gt_ok" if ok else "gt_bad"] += count
+    except Exception as e:
+        print(f"[metrics] get_terminal precompute skipped: {e}", flush=True)
+
+    if not metrics_buckets:
+        return
 
     print(f"Precomputed metrics: {len(metrics_buckets)} buckets from {total_events} events (aggregated)", flush=True)
 
@@ -670,18 +719,28 @@ def get_metrics_timeseries():
     for key in sorted(metrics_buckets):
         b = metrics_buckets[key]
         put_total = b["put_req"] or b["put_ok"]
-        get_total = b["get_ok"] + b["get_nf"]
         upd_total = b["upd_req"] or b["upd_ok"]
+        # GET success is measured from get_terminal only. Deriving it from the
+        # per-hop get_success/get_not_found counts understated it by ~600x
+        # during the 2026-07-26 growth surge (issue #15).
+        get_total = b["gt_ok"] + b["gt_bad"]
+        get_sub_total = b["gt_sub_ok"] + b["gt_sub_bad"]
+        sub_total = b["sub_ok"] + b["sub_bad"]
 
         series.append({
             "t": b["ts"],
             "put_rate": rate_or_none(b["put_ok"], put_total),
-            "get_rate": rate_or_none(b["get_ok"], get_total),
+            "get_rate": rate_or_none(b["gt_ok"], get_total),
+            "get_sub_rate": rate_or_none(b["gt_sub_ok"], get_sub_total),
             "upd_rate": rate_or_none(b["upd_ok"], upd_total),
+            "sub_rate": rate_or_none(b["sub_ok"], sub_total),
             "put_n": put_total,
             "get_n": get_total,
+            "get_sub_n": get_sub_total,
             "upd_n": upd_total,
-            "sub_n": b["sub_ok"],
+            "sub_n": sub_total,
+            # Per-hop routing volume. Deliberately not a success signal.
+            "get_hops_n": b["get_req"] + b["get_nf"],
             "lat_put": p50(b["lat_put"]),
             "lat_get": p50(b["lat_get"]),
             "lat_upd": p50(b["lat_upd"]),
@@ -808,7 +867,9 @@ peer_lifecycle = {}
 pending_ops = {}
 
 # Transaction tracking - store full event sequences for timeline lanes
-# tx_id -> {"op": type, "contract": key, "events": [...], "start_ns": ts, "end_ns": ts, "status": "pending"|"success"|"failed"}
+# tx_id -> {"op": type, "contract": key, "events": [...], "start_ns": ts,
+#           "end_ns": ts, "tx_shape": "open"|"settled"|"partial",
+#           "outcome": measured result or None (see TX_TERMINAL_EVENTS)}
 MAX_TRANSACTIONS = 10000  # Keep last N transactions
 MAX_INITIAL_TRANSACTIONS = 500  # Transactions sent to clients on connect
 transactions = {}  # tx_id -> transaction data
@@ -1192,11 +1253,89 @@ def precompute_propagation_from_db():
         print(f"  {ck[:24]}: {len(p.get('peers', {}))} peers, {ms/1000:.1f}s", flush=True)
 
 
-def track_transaction(tx_id, event_type, timestamp, peer_id, contract_key=None, body_type=None):
+# ── Transaction classification (issue #15) ────────────────────────────────
+#
+# A transaction is described by two independent facts:
+#   tx_shape — what we OBSERVED: 'open' / 'settled' / 'partial'
+#   outcome  — what was MEASURED, and only when tx_shape == 'settled'
+#
+# The pair replaced a single `status` column whose 'complete' value was really
+# "the first event we saw wasn't a start event". Propagation events dominate
+# that case, so ~29M synthetic completions accumulated over 48h and any success
+# rate taken from the column was confidently wrong.
+
+# Events that genuinely START an operation.
+TX_START_EVENTS = {
+    "put_request": "put",
+    "get_request": "get",
+    "update_request": "update",
+    "subscribe_request": "subscribe",
+    "connect_request_sent": "connect",
+}
+
+# Events carrying a MEASURED terminal outcome for the whole operation, as
+# event_type -> (op_type, outcome).
+#
+# get_success / get_not_found are deliberately ABSENT. The core emits them once
+# per HOP, so settling a transaction on one reports a relay's local view as the
+# client's — the exact confusion this issue is about. `get_terminal` is the only
+# event carrying the outcome the requesting client actually saw, and it is
+# handled separately below because its outcome comes from the event body.
+TX_TERMINAL_EVENTS = {
+    "put_success": ("put", "success"),
+    "put_failure": ("put", "failure"),
+    "update_success": ("update", "success"),
+    "update_failure": ("update", "failure"),
+    "subscribe_success": ("subscribe", "success"),
+    "subscribe_not_found": ("subscribe", "not_found"),
+    "subscribe_timeout": ("subscribe", "timeout"),
+    # Legacy alias. No core release in the retention window emits `subscribed`
+    # (the live DB holds zero of them) — it is kept only so a peer running old
+    # code cannot go permanently unsettled, which is the bug this replaces.
+    "subscribed": ("subscribe", "success"),
+    "connect_connected": ("connect", "success"),
+    "connect_rejected": ("connect", "rejected"),
+    "disconnect": ("disconnect", "disconnected"),
+}
+
+TRACKED_TX_OPS = {"put", "get", "update", "broadcast", "connect", "subscribe"}
+
+
+def classify_tx_event(event_type):
+    """Map an event type to (op_type, role) where role is 'start', 'terminal'
+    or None. Kept separate from track_transaction so the classification can be
+    tested directly, and mirrored in js/events.js."""
+    if event_type in TX_START_EVENTS:
+        return TX_START_EVENTS[event_type], "start"
+    if event_type in TX_TERMINAL_EVENTS:
+        return TX_TERMINAL_EVENTS[event_type][0], "terminal"
+    if event_type == "get_terminal":
+        return "get", "terminal"
+    if event_type.startswith("put_"):
+        return "put", None
+    if event_type.startswith("get_"):
+        return "get", None
+    if event_type.startswith("update_"):
+        return "update", None
+    if event_type.startswith("subscribe") or event_type in ("unsubscribed",):
+        return "subscribe", None
+    if event_type.startswith("connect"):
+        return "connect", None
+    if "broadcast" in event_type:
+        return "broadcast", None
+    parts = event_type.split("_")
+    return (parts[0] if parts else "other"), None
+
+
+def track_transaction(tx_id, event_type, timestamp, peer_id, contract_key=None,
+                      body_type=None, terminal_outcome=None):
     """Track an event as part of a transaction for timeline lanes.
 
     All events with a valid transaction ID are tracked. Events are grouped by
     transaction ID to show related events together in the timeline.
+
+    `terminal_outcome` supplies the measured result for events that carry it in
+    their body (currently only get_terminal).
     """
     if not tx_id or tx_id == "00000000000000000000000000":
         return  # Skip null transaction IDs
@@ -1204,77 +1343,24 @@ def track_transaction(tx_id, event_type, timestamp, peer_id, contract_key=None, 
     # Use body_type for more specific event type if available (especially for connect events)
     display_event_type = body_type if body_type else event_type
 
-    # Determine operation type from event type prefix
-    op_type = None
-    is_start = False
-    is_end = False
-    status = None
-
-    # Derive op_type from event_type prefix
-    if event_type.startswith("put_"):
-        op_type = "put"
-        if event_type == "put_request":
-            is_start = True
-        elif event_type == "put_success":
-            is_end = True
-            status = "success"
-    elif event_type.startswith("get_"):
-        op_type = "get"
-        if event_type == "get_request":
-            is_start = True
-        elif event_type == "get_success":
-            is_end = True
-            status = "success"
-        elif event_type == "get_not_found":
-            is_end = True
-            status = "not_found"
-    elif event_type.startswith("update_"):
-        op_type = "update"
-        if event_type == "update_request":
-            is_start = True
-        elif event_type == "update_success":
-            is_end = True
-            status = "success"
-    elif event_type.startswith("subscribe"):
-        op_type = "subscribe"
-        if event_type == "subscribe_request":
-            is_start = True
-        elif event_type == "subscribed":
-            is_end = True
-            status = "success"
-    elif event_type.startswith("connect"):
-        op_type = "connect"
-        if event_type == "connect_request_sent":
-            is_start = True
-        elif event_type == "connect_connected":
-            is_end = True
-            status = "success"
-    elif event_type == "disconnect":
-        op_type = "disconnect"
-        is_start = True
-        is_end = True
-        status = "complete"
-    elif "broadcast" in event_type:
-        op_type = "broadcast"
+    op_type, role = classify_tx_event(event_type)
+    is_start = role == "start"
+    is_end = role == "terminal"
+    if is_end:
+        if event_type == "get_terminal":
+            # Outcome comes from the event body; without it we have not
+            # measured anything, so refuse to claim a result.
+            outcome = terminal_outcome
+            if outcome is None:
+                is_end = False
+        else:
+            outcome = TX_TERMINAL_EVENTS[event_type][1]
     else:
-        # For any other event type, use the prefix before underscore as op_type
-        parts = event_type.split("_")
-        op_type = parts[0] if parts else "other"
+        outcome = None
 
-    TRACKED_TX_OPS = {"put", "get", "update", "broadcast", "connect", "subscribe"}
     if op_type not in TRACKED_TX_OPS and tx_id not in transactions:
         return  # Skip noisy transaction types
 
-    # Create or update transaction
-    #
-    # WARNING: "status" is NOT a measured operation outcome, and must not be
-    # read as one. "complete" here is a FALLBACK for any transaction whose
-    # first observed event simply isn't a start event — which is the common
-    # case for propagation events (every update_broadcast_received mints a
-    # "complete" update tx). SUBSCRIBE has no terminal handler at all, so its
-    # transactions stay "pending" forever. Computing a success rate from this
-    # column produces confident, badly wrong numbers. For real client-facing
-    # GET outcomes use the get_terminal event (outcome / is_sub_op / attempts).
     if tx_id not in transactions:
         transactions[tx_id] = {
             "op": op_type or "unknown",
@@ -1282,7 +1368,11 @@ def track_transaction(tx_id, event_type, timestamp, peer_id, contract_key=None, 
             "events": [],
             "start_ns": timestamp,
             "end_ns": None,
-            "status": "pending" if is_start and not is_end else "complete",
+            # 'partial' is the honest default: we have seen an event for this
+            # transaction but neither its start nor a terminal, so we know
+            # nothing about how it ended.
+            "tx_shape": "open" if is_start else "partial",
+            "outcome": None,
         }
         transaction_order.append(tx_id)
         prune_old_transactions()
@@ -1307,10 +1397,14 @@ def track_transaction(tx_id, event_type, timestamp, peer_id, contract_key=None, 
     if timestamp < tx["start_ns"]:
         tx["start_ns"] = timestamp
 
-    # Update end time and status
+    if is_start and tx["tx_shape"] == "partial":
+        tx["tx_shape"] = "open"
+
+    # Update end time and shape/outcome
     if is_end:
         tx["end_ns"] = timestamp
-        tx["status"] = status or "complete"
+        tx["tx_shape"] = "settled"
+        tx["outcome"] = outcome
     elif timestamp > (tx["end_ns"] or 0):
         tx["end_ns"] = timestamp
 
@@ -1326,7 +1420,7 @@ def track_transaction(tx_id, event_type, timestamp, peer_id, contract_key=None, 
     db.upsert_transaction(
         tx_id, tx["op"], tx["contract"], contract_short,
         tx["start_ns"], tx["end_ns"] or tx["start_ns"],
-        tx["status"], duration_ms, len(tx["events"])
+        tx["tx_shape"], tx["outcome"], duration_ms, len(tx["events"])
     )
     if is_end:
         db.compute_flows_for_tx(tx_id)
@@ -1455,12 +1549,16 @@ def process_record(record, store_history=True):
             del pending_ops[tx_id]
         record_metric("put_success", timestamp, _lat, peer_id=event_peer_id)
     elif event_type == "get_request":
-        op_stats["get"]["requests"] += 1
+        # Per-HOP counter. Not a denominator for any success rate.
+        op_stats["get"]["hop_requests"] += 1
         record_metric("get_request", timestamp, peer_id=event_peer_id)
         if tx_id:
             pending_ops[tx_id] = {"op": "get", "start_ns": timestamp}
     elif event_type == "get_success":
-        op_stats["get"]["successes"] += 1
+        # Latency only. This event is per-HOP, so it must never feed a success
+        # rate — but the request->success delta is still the best GET timing
+        # signal available: get_terminal reports elapsed_ms=0 on 99.5% of
+        # successful direct GETs, so it cannot serve as a latency source.
         _lat = None
         if tx_id and tx_id in pending_ops:
             latency_ms = (timestamp - pending_ops[tx_id]["start_ns"]) / 1_000_000
@@ -1472,10 +1570,20 @@ def process_record(record, store_history=True):
             del pending_ops[tx_id]
         record_metric("get_success", timestamp, _lat, peer_id=event_peer_id)
     elif event_type == "get_not_found":
-        op_stats["get"]["not_found"] += 1
+        # Per-HOP counter: one per relay that lacked the contract, so this
+        # tracks route length rather than user-visible failure.
+        op_stats["get"]["hop_not_found"] += 1
         record_metric("get_not_found", timestamp, peer_id=event_peer_id)
         if tx_id and tx_id in pending_ops:
             del pending_ops[tx_id]
+    elif event_type == "get_terminal":
+        # The client-facing outcome, and the ONLY basis for GET success rates.
+        _outcome = body.get("outcome")
+        _sub = bool(body.get("is_sub_op"))
+        _bucket = op_stats["get"]["term_sub_op" if _sub else "term_direct"]
+        _bucket[_outcome if _outcome in _bucket else "other"] += 1
+        record_metric("get_terminal", timestamp, peer_id=event_peer_id,
+                      outcome=_outcome, is_sub_op=_sub)
     elif event_type == "update_request":
         op_stats["update"]["requests"] += 1
         record_metric("update_request", timestamp, peer_id=event_peer_id)
@@ -1497,9 +1605,17 @@ def process_record(record, store_history=True):
         op_stats["update"]["broadcasts"] += 1
     elif event_type == "subscribe_request":
         op_stats["subscribe"]["requests"] += 1
-    elif event_type == "subscribed":
+    elif event_type in ("subscribe_success", "subscribed"):
+        # `subscribed` is a legacy alias the core no longer emits; keying only
+        # on it pinned every subscribe counter at zero (issue #15).
         op_stats["subscribe"]["successes"] += 1
-        record_metric("subscribed", timestamp, peer_id=event_peer_id)
+        record_metric("subscribe_success", timestamp, peer_id=event_peer_id)
+    elif event_type == "subscribe_not_found":
+        op_stats["subscribe"]["not_found"] += 1
+        record_metric("subscribe_not_found", timestamp, peer_id=event_peer_id)
+    elif event_type == "subscribe_timeout":
+        op_stats["subscribe"]["timeouts"] += 1
+        record_metric("subscribe_timeout", timestamp, peer_id=event_peer_id)
 
     # Handle transfer_completed events for congestion control visualization
     elif event_type == "transfer_completed":
@@ -1998,7 +2114,9 @@ def process_record(record, store_history=True):
     if tx_id and tx_id != "00000000000000000000000000":
         event["tx_id"] = tx_id
         # Track this event as part of the transaction (pass body_type for specific connect events)
-        track_transaction(tx_id, event_type, timestamp, event["peer_id"], contract_key, body_type)
+        track_transaction(tx_id, event_type, timestamp, event["peer_id"], contract_key,
+                          body_type, terminal_outcome=event.get("outcome")
+                          if event_type == "get_terminal" else None)
 
     # Store in history buffer and SQLite DB
     if store_history and event_type in HISTORY_EVENT_TYPES:
@@ -2010,6 +2128,15 @@ def process_record(record, store_history=True):
                 return event  # skip storage, still return for real-time broadcast
         event_history.append(event)
         db.insert_event(event)
+        # Project the client-facing GET outcome into its own small table so
+        # GET health can be aggregated without scanning the events table.
+        if event_type == "get_terminal" and event.get("outcome") is not None:
+            db.insert_get_terminal(
+                timestamp, tx_id or None, event["peer_id"], contract_key,
+                event["outcome"], bool(event.get("is_sub_op")),
+                event.get("attempts"), event.get("hop_count"),
+                event.get("elapsed_ms"),
+            )
         if len(event_history) % 100 == 0:
             prune_old_events()
 
@@ -2039,16 +2166,30 @@ def get_operation_stats():
     update = op_stats["update"]
     subscribe = op_stats["subscribe"]
 
+    direct = get["term_direct"]
+    sub_op = get["term_sub_op"]
+    direct_total = sum(direct.values())
+    sub_op_total = sum(sub_op.values())
+    sub_total = (subscribe["successes"] + subscribe["not_found"]
+                 + subscribe["timeouts"])
+
     return {
         "put": {
             "total": put["requests"],
             "success_rate": calc_rate(put["successes"], put["requests"]),
             "latency": calc_percentiles(put["latencies"]),
         },
+        # GET rates are measured from get_terminal, the client-facing outcome.
+        # The per-hop counts are still reported, under names that cannot be
+        # mistaken for an outcome (issue #15).
         "get": {
-            "total": get["requests"] + get["successes"],  # get_success without get_request
-            "success_rate": calc_rate(get["successes"], get["successes"] + get["not_found"]) if (get["successes"] + get["not_found"]) > 0 else None,
-            "not_found": get["not_found"],
+            "total": direct_total,
+            "success_rate": calc_rate(direct["success"], direct_total) if direct_total else None,
+            "not_found": direct["not_found"],
+            "sub_op_total": sub_op_total,
+            "sub_op_success_rate": calc_rate(sub_op["success"], sub_op_total) if sub_op_total else None,
+            "hop_requests": get["hop_requests"],
+            "hop_not_found": get["hop_not_found"],
             "latency": calc_percentiles(get["latencies"]),
         },
         "update": {
@@ -2058,7 +2199,11 @@ def get_operation_stats():
             "latency": calc_percentiles(update["latencies"]),
         },
         "subscribe": {
-            "total": subscribe["successes"],  # subscribed events
+            "total": sub_total,
+            "requests": subscribe["requests"],
+            "success_rate": calc_rate(subscribe["successes"], sub_total) if sub_total else None,
+            "not_found": subscribe["not_found"],
+            "timeouts": subscribe["timeouts"],
         },
     }
 
@@ -2358,7 +2503,8 @@ def get_transactions_list():
                 "start_ns": tx["start_ns"],
                 "end_ns": tx["end_ns"] or tx["start_ns"],  # Use start if no end yet
                 "duration_ms": duration_ms,
-                "status": tx["status"],
+                "tx_shape": tx["tx_shape"],
+                "outcome": tx["outcome"],
                 "event_count": len(tx["events"]),
                 "events": tx["events"],  # Include full event list for detail view
             })

--- a/ws_server.py
+++ b/ws_server.py
@@ -1317,7 +1317,7 @@ def classify_tx_event(event_type):
         return "get", None
     if event_type.startswith("update_"):
         return "update", None
-    if event_type.startswith("subscribe") or event_type in ("unsubscribed",):
+    if event_type.startswith("subscribe"):
         return "subscribe", None
     if event_type.startswith("connect"):
         return "connect", None
@@ -1576,9 +1576,12 @@ def process_record(record, store_history=True):
         record_metric("get_not_found", timestamp, peer_id=event_peer_id)
         if tx_id and tx_id in pending_ops:
             del pending_ops[tx_id]
-    elif event_type == "get_terminal":
+    elif event_type == "get_terminal" and body.get("outcome") is not None:
         # The client-facing outcome, and the ONLY basis for GET success rates.
-        _outcome = body.get("outcome")
+        # An event without an outcome has measured nothing, so it is skipped
+        # rather than counted as a failure — track_transaction refuses to settle
+        # on it for the same reason, and the two must not disagree.
+        _outcome = body["outcome"]
         _sub = bool(body.get("is_sub_op"))
         _bucket = op_stats["get"]["term_sub_op" if _sub else "term_direct"]
         _bucket[_outcome if _outcome in _bucket else "other"] += 1


### PR DESCRIPTION
## Problem

`transactions.status` looked like an operation outcome and was not one, so any success rate computed from it was confidently wrong. Three defects, all confirmed against the live telemetry database before any code was changed:

**1. `complete` was a fallback, not a result.** `"pending" if is_start and not is_end else "complete"` labelled every transaction whose *first observed event* simply wasn't a start event. Propagation events dominate that case:

| op | status | rows |
|---|---|---|
| update | complete | 875,850 |
| subscribe | complete | 275,993 |
| get | complete | 194,734 |
| get | success | **4,080** |

**2. The SUBSCRIBE terminal handler keyed on an event the core never emits.** It looked for `subscribed`; the core emits `subscribe_success` / `subscribe_not_found` / `subscribe_timeout` (`crates/core/src/tracing/telemetry.rs:963`). `subscribed` has **zero** occurrences in the entire database, against 594,480 `subscribe_success`. Result: 990,918 subscribes stuck `pending` forever, and because `op_stats` and the metrics bucket `sub_ok` keyed on the same dead name, every subscribe counter read zero.

**3. The Performance chart derived GET success from per-hop events.** `get_rate = get_success / (get_success + get_not_found)`, both emitted once per HOP, so the ratio tracked route length. Measured per 4h bucket over 24h — what the chart plotted vs. what clients actually saw:

| bucket (UTC) | charted | direct GET (real) | sub-op GET (real) |
|---|---|---|---|
| 07-28 20:00 | 0.13% | 92.2% | 28.9% |
| 07-29 04:00 | 0.10% | 88.0% | 14.3% |
| 07-29 08:00 | 0.05% | 90.5% | 15.9% |
| 07-29 12:00 | 0.14% | 86.8% | 28.0% |

A ~600x understatement, and the genuine regression — sub-op GETs failing 60-85% of the time — was invisible.

## Approach

Replace `status` with two independent columns, so the wrong query returns no rows instead of a wrong number:

- **`tx_shape`** — what was OBSERVED: `open` (start seen, no terminal) / `settled` (a genuine terminal seen) / `partial` (events seen, but neither).
- **`outcome`** — what was MEASURED. `NULL` unless `tx_shape = 'settled'`.

`get_success`/`get_not_found` are deliberately **not** terminals: settling on one reports a relay's local view as the client's. `get_terminal` is the sole authority for GET, split direct vs sub-op, and the sub-op line is now plotted — that is the signal the old metric hid.

Why not the issue's third suggestion (only create a row on a genuine start): those rows carry the timeline lanes. Making the shape honest fixes the misreading without dropping timeline data.

**Server and client are changed together** (`js/events.js`, `js/metrics.js`), and a test pins them to the same classification tables so they cannot drift.

Notes for review:
- `put_failure`, `update_failure` and `connect_rejected` are now terminals. They weren't before, and they are genuine measured outcomes.
- GET **latency** deliberately still comes from the request→success delta. `get_terminal` reports `elapsed_ms = 0` on 99.5% of successful direct GETs, so using it would have flattened the latency chart to zero — a regression this PR avoids and pins with a test.
- New `get_terminals` projection table (~200k rows/day, pruned with everything else) so GET health aggregates without scanning the multi-hundred-GB events table, which has no `event_type` index.
- Migration is gated on `PRAGMA user_version`. Timed at production row count (2,931,393): **7.1s once**, 0.001s on subsequent opens.

## Testing

The repo had **no tests and no CI**; both are added here (`pytest` + a workflow that also byte-compiles the Python and parses the ES modules).

92 tests. Every one of the original 59 was verified to **fail** against unfixed code, and the later additions were mutation-checked individually — which caught one vacuous test (its sentinel value was one the migration never rewrites, so it passed with the gate removed) that is now fixed.

Coverage: phantom-completion prevention, subscribe terminals incl. the legacy alias, hop-vs-client GET outcomes, the ~600x rate bug reproduced directly, sub-op visibility, the zero-elapsed latency trap, schema migration and idempotency, `get_terminals` round-trip and pruning, server↔client classification agreement, and `backfill_db.py` (an independent writer of the same table that previously had no tests, and which marked `get_not_found` as `"success"` outright).

Note: `node --check <file>` silently passes invalid ES modules on Node 22, so the workflow uses `node --input-type=module --check < file`, verified to catch a real syntax error.

## Follow-up (not in this PR)

The orphaned root `app.js` (161 KB) still contains the entire pre-modularization version of this bug — `tx.status`, `subscribed` as the subscribe terminal, `get_not_found` as a GET terminal, and it renders `Status: ${tx.status || 'unknown'}`. Nothing loads it (`index.html` loads only `js/app.js`) and nothing references it, nor `app.js.backup`, `app.js.before-issue5`, or `ws_server.py.backup`. Worth deleting, but that is four files I did not author, so I left the call to you.

Closes #15

[AI-assisted - Claude]
