### PR TITLE
fix: make the migration additive and stop publishing an unmeasurable rate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,24 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'
+      - uses: actions/setup-node@v4
+        # The client/server agreement tests drive the real js/events.js through
+        # node rather than reimplementing it. They skip without node, so it has
+        # to be present here or the agreement is silently unverified.
+        with:
+          node-version: '20'
       - name: Install dependencies
         run: pip install -r requirements-dev.txt
       - name: Run tests
         run: python -m pytest tests/ -v
+      - name: Fail if the cross-runtime agreement tests were skipped
+        run: |
+          python -m pytest tests/test_server_client_agreement.py -q -rs \
+            | tee /tmp/agree.txt
+          if grep -q "skipped" /tmp/agree.txt; then
+            echo "agreement tests skipped — node missing, agreement unverified"
+            exit 1
+          fi
 
   syntax:
     runs-on: ubuntu-latest

--- a/backfill_db.py
+++ b/backfill_db.py
@@ -19,6 +19,9 @@ from pathlib import Path
 
 import orjson
 
+import ws_server
+from telemetry_db import SCHEMA_TABLES
+
 TELEMETRY_LOG = Path("/mnt/media/freenet-telemetry/logs.jsonl")
 DB_PATH = "/var/www/freenet-dashboard/telemetry.db"
 
@@ -44,26 +47,16 @@ HISTORY_EVENT_TYPES = {
 
 TRACKED_TX_OPS = {"put", "get", "update", "broadcast", "connect", "subscribe"}
 
-# Must mirror TX_START_EVENTS / TX_TERMINAL_EVENTS in ws_server.py. get_success
-# and get_not_found are per-HOP and so are NOT terminals; get_terminal is the
-# client-facing GET outcome and is handled inline (its result is in the body).
-TX_START_EVENTS = {
-    "put_request", "get_request", "update_request",
-    "subscribe_request", "connect_request_sent",
-}
-TX_TERMINAL_EVENTS = {
-    "put_success": "success",
-    "put_failure": "failure",
-    "update_success": "success",
-    "update_failure": "failure",
-    "subscribe_success": "success",
-    "subscribe_not_found": "not_found",
-    "subscribe_timeout": "timeout",
-    "subscribed": "success",  # legacy alias, no longer emitted
-    "connect_connected": "success",
-    "connect_rejected": "rejected",
-    "disconnect": "disconnected",
-}
+# Imported rather than copied. This script previously kept its own transcription
+# of the classification tables and drifted from the server twice: it keyed
+# subscribes off `subscribed` (an event the core never emits) and recorded
+# get_not_found as "success". Sharing the definitions makes that class of bug
+# unrepresentable. get_success/get_not_found are per-HOP and so are not
+# terminals; get_terminal is the client-facing GET outcome and is handled
+# inline, because its result lives in the event body.
+TX_START_EVENTS = set(ws_server.TX_START_EVENTS)
+TX_TERMINAL_EVENTS = {k: v[1] for k, v in ws_server.TX_TERMINAL_EVENTS.items()}
+outcome_wins = ws_server.outcome_wins
 
 PEER_PATTERN = re.compile(r'(\w+)@(\d+\.\d+\.\d+\.\d+):(\d+)\s*\(@\s*([\d.]+)\)')
 
@@ -146,51 +139,16 @@ def main():
     conn.execute("PRAGMA cache_size=-256000")  # 256MB cache
     conn.execute("PRAGMA temp_store=MEMORY")
 
-    # Create tables without indexes (add after bulk insert)
-    conn.executescript("""
-        CREATE TABLE events (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            timestamp_ns INTEGER NOT NULL,
-            event_type TEXT NOT NULL,
-            peer_id TEXT,
-            tx_id TEXT,
-            contract_key TEXT,
-            data TEXT NOT NULL
-        );
-        CREATE TABLE transactions (
-            tx_id TEXT PRIMARY KEY,
-            op TEXT NOT NULL,
-            contract_key TEXT,
-            contract_short TEXT,
-            start_ns INTEGER NOT NULL,
-            end_ns INTEGER,
-            tx_shape TEXT DEFAULT 'partial',
-            outcome TEXT,
-            duration_ms REAL,
-            event_count INTEGER DEFAULT 0
-        );
-        CREATE TABLE tx_events (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            tx_id TEXT NOT NULL,
-            timestamp_ns INTEGER NOT NULL,
-            event_type TEXT NOT NULL,
-            peer_id TEXT
-        );
-        CREATE TABLE flows (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            timestamp_ns INTEGER NOT NULL,
-            from_peer TEXT NOT NULL,
-            to_peer TEXT NOT NULL,
-            event_type TEXT NOT NULL,
-            tx_id TEXT
-        );
-        CREATE TABLE meta (
-            key TEXT PRIMARY KEY,
-            value TEXT
-        );
-    """)
+    # Tables come from the server's own schema rather than a transcription of
+    # it. The previous hand-copy silently omitted get_terminals, which is where
+    # GET success rates are sourced from — so a database rebuilt by this script
+    # produced a Performance chart with PUT and UPDATE restored and both GET
+    # lines blank, the exact metric this work exists to fix. SCHEMA_TABLES
+    # carries no indexes; those are still added after the bulk insert.
+    conn.executescript(SCHEMA_TABLES)
 
     event_buf = []
+    getterm_buf = []
     tx_data = {}  # tx_id -> {op, contract, start_ns, end_ns, tx_shape, outcome, events}
     count = 0
     stored = 0
@@ -312,6 +270,7 @@ def main():
                                         "op": op, "contract": contract_key,
                                         "start_ns": ts, "end_ns": ts,
                                         "tx_shape": "partial", "outcome": None,
+                                        "outcome_src": None,
                                         "events": [],
                                     }
                                 tx = tx_data[tx_id]
@@ -327,14 +286,32 @@ def main():
                                 if display_type in TX_START_EVENTS:
                                     if tx["tx_shape"] == "partial":
                                         tx["tx_shape"] = "open"
-                                elif display_type in TX_TERMINAL_EVENTS:
-                                    tx["tx_shape"] = "settled"
-                                    tx["outcome"] = TX_TERMINAL_EVENTS[display_type]
-                                elif display_type == "get_terminal":
-                                    outcome = body.get("outcome")
+                                else:
+                                    if display_type in TX_TERMINAL_EVENTS:
+                                        outcome = TX_TERMINAL_EVENTS[display_type]
+                                    elif display_type == "get_terminal":
+                                        outcome = body.get("outcome")
+                                    else:
+                                        outcome = None
                                     if outcome:
                                         tx["tx_shape"] = "settled"
-                                        tx["outcome"] = outcome
+                                        # Same precedence as the server: several
+                                        # hop-observed terminals can land on one
+                                        # transaction and can contradict.
+                                        if outcome_wins(outcome, display_type,
+                                                        tx["outcome"], tx["outcome_src"]):
+                                            tx["outcome"] = outcome
+                                            tx["outcome_src"] = display_type
+
+                        # Project the client-facing GET outcome, the source the
+                        # server computes GET success rates from.
+                        if display_type == "get_terminal" and body.get("outcome"):
+                            getterm_buf.append((
+                                ts, tx_id, peer_id, contract_key,
+                                body["outcome"], 1 if body.get("is_sub_op") else 0,
+                                body.get("attempts"), body.get("hop_count"),
+                                body.get("elapsed_ms"),
+                            ))
 
                         stored += 1
 
@@ -366,7 +343,18 @@ def main():
         )
         conn.execute("COMMIT")
 
+    if getterm_buf:
+        conn.execute("BEGIN")
+        conn.executemany(
+            "INSERT INTO get_terminals (timestamp_ns, tx_id, peer_id, contract_key, "
+            "outcome, is_sub_op, attempts, hop_count, elapsed_ms) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            getterm_buf,
+        )
+        conn.execute("COMMIT")
+
     print(f"\n  Events: {stored:,} stored")
+    print(f"  GET terminals: {len(getterm_buf):,} stored")
 
     # Insert transactions and tx_events
     print("  Writing transactions and computing flows...")

--- a/create_indexes.py
+++ b/create_indexes.py
@@ -16,7 +16,7 @@ import sys
 import time
 import sqlite3
 
-from telemetry_db import DEFAULT_DB_PATH, SCHEMA_INDEXES
+from telemetry_db import DEFAULT_DB_PATH, SCHEMA_INDEXES, SCHEMA_TABLES
 
 
 def main():
@@ -28,6 +28,13 @@ def main():
     conn.execute("PRAGMA cache_size=-1048576")  # 1GB cache for index build
     conn.execute("PRAGMA temp_store=MEMORY")
     conn.execute("PRAGMA busy_timeout=60000")
+
+    # Create any missing tables first. This script runs while the server is
+    # stopped, so on a database predating a new table (get_terminals, issue
+    # #15) nothing else would have created it, and the index statement below
+    # would fail with "no such table" and abort every index after it.
+    # CREATE TABLE IF NOT EXISTS makes this a no-op in the normal case.
+    conn.executescript(SCHEMA_TABLES)
 
     # Show existing indexes
     existing = set()

--- a/js/events.js
+++ b/js/events.js
@@ -399,7 +399,7 @@ export function classifyTxEvent(eventType) {
     if (eventType.startsWith('put_')) return { op: 'put', role: null };
     if (eventType.startsWith('get_')) return { op: 'get', role: null };
     if (eventType.startsWith('update_')) return { op: 'update', role: null };
-    if (eventType.startsWith('subscribe') || eventType === 'unsubscribed') return { op: 'subscribe', role: null };
+    if (eventType.startsWith('subscribe')) return { op: 'subscribe', role: null };
     if (eventType.startsWith('connect')) return { op: 'connect', role: null };
     if (eventType.includes('broadcast')) return { op: 'broadcast', role: null };
     return { op: eventType.split('_')[0] || 'other', role: null };

--- a/js/events.js
+++ b/js/events.js
@@ -389,6 +389,38 @@ const TX_TERMINAL_EVENTS = {
     disconnect: ['disconnect', 'disconnected'],
 };
 
+// Hop-observed terminals arrive once per peer on the response path, so one
+// transaction can produce several and for SUBSCRIBE they can contradict each
+// other. Resolving by arrival order made the stored outcome depend on ingest
+// order. Keep this table and outcomeWins() in step with TX_OUTCOME_PRECEDENCE
+// and outcome_wins() in ws_server.py — the resolution rule is part of what the
+// two sides must agree on, not just the classification.
+const TX_OUTCOME_PRECEDENCE = {
+    success: 7,
+    not_found: 6,
+    timeout_exhausted: 5,
+    timeout: 4,
+    rejected: 3,
+    failure: 2,
+    disconnected: 1,
+};
+
+// Only GET has a client-facing terminal; the core has no ClientTerminal
+// analogue on SubscribeEvent, PutEvent or UpdateEvent.
+const CLIENT_FACING_TERMINALS = new Set(['get_terminal']);
+
+/**
+ * Should `newOutcome` replace `oldOutcome` on the same transaction?
+ * A client-facing terminal is authoritative and is never overridden by a
+ * hop-observed one; otherwise the higher precedence wins, deterministically.
+ */
+export function outcomeWins(newOutcome, newEventType, oldOutcome, oldEventType) {
+    if (oldOutcome == null) return true;
+    if (CLIENT_FACING_TERMINALS.has(oldEventType)) return false;
+    if (CLIENT_FACING_TERMINALS.has(newEventType)) return true;
+    return (TX_OUTCOME_PRECEDENCE[newOutcome] || 0) > (TX_OUTCOME_PRECEDENCE[oldOutcome] || 0);
+}
+
 /**
  * Map an event type to { op, role } where role is 'start', 'terminal' or null.
  */
@@ -453,7 +485,10 @@ export function trackTransactionFromEvent(event) {
         }
         if (isEnd) {
             tx.tx_shape = 'settled';
-            tx.outcome = outcome;
+            if (outcomeWins(outcome, eventType, tx.outcome, tx.outcome_src)) {
+                tx.outcome = outcome;
+                tx.outcome_src = eventType;
+            }
             tx.duration_ms = (tx.end_ns - tx.start_ns) / 1_000_000;
         }
     } else {
@@ -470,6 +505,9 @@ export function trackTransactionFromEvent(event) {
             // but neither its start nor a terminal, so its result is unknown.
             tx_shape: isEnd ? 'settled' : (isStart ? 'open' : 'partial'),
             outcome: isEnd ? outcome : null,
+            // Which event set `outcome`, so a hop-observed terminal cannot
+            // overwrite a client-facing one.
+            outcome_src: isEnd ? eventType : null,
             event_count: 1,
             events: [{
                 event_type: eventType,

--- a/telemetry_db.py
+++ b/telemetry_db.py
@@ -196,14 +196,24 @@ SCHEMA_INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_txe_txid ON tx_events(tx_id)",
     "CREATE INDEX IF NOT EXISTS idx_txe_type_ts ON tx_events(event_type, timestamp_ns)",
     "CREATE INDEX IF NOT EXISTS idx_txe_peer_ts ON tx_events(peer_id, event_type, timestamp_ns)",
-    # get_terminals deliberately has NO index. Measured on a full 24h window
-    # (250k rows): the startup aggregate in get_terminal_buckets takes 382ms
-    # scanning and 799ms with an index on timestamp_ns — it groups the entire
-    # retention window, so a table scan beats index-ordered row lookups. The
-    # only query an index helps is prune's probe (65ms -> 22ms against a 5s
-    # budget). Adding one would also make correctness depend on an operator
-    # remembering to run create_indexes.py. The table is bounded by retention,
-    # so scanning is the right plan; revisit only if retention grows a lot.
+    # get_terminals deliberately has NO index on timestamp_ns, for a structural
+    # reason rather than a benchmarked one. get_terminal_buckets is called with
+    # since_ns = METRICS_MAX_AGE_NS (8 days) against a 24h retention, so its
+    # WHERE matches every row by construction, and it GROUPs BY a computed
+    # bucket expression that no timestamp_ns index can serve — the query plan
+    # keeps its temp B-tree either way. An index therefore cannot help the only
+    # query this table exists for, at any row count. It would also make
+    # correctness depend on an operator running create_indexes.py, since
+    # nothing creates indexes at startup.
+    #
+    # The cost that DOES grow is prune's probe, which scans. The trigger is GET
+    # volume rising at fixed retention, not retention changing. Measured:
+    # 250k rows 382ms aggregate / 14ms probe; 500k 977/51; 1M 2142/167. prune
+    # blocks the asyncio event loop and probes at least twice per cycle, so 1M
+    # rows is roughly a 330ms stall per cycle with nothing alarming on it.
+    # Cheap now and linear from here — but this module's own retention comment
+    # records the network doubling in two days, so revisit when get_terminals
+    # approaches ~1M rows in a window.
     "CREATE INDEX IF NOT EXISTS idx_flows_ts ON flows(timestamp_ns)",
     "CREATE INDEX IF NOT EXISTS idx_flows_tx ON flows(tx_id) WHERE tx_id IS NOT NULL",
     "CREATE INDEX IF NOT EXISTS idx_flows_type_ts ON flows(event_type, timestamp_ns)",
@@ -283,7 +293,17 @@ class TelemetryDB:
         cols = {row[1] for row in self.conn.execute("PRAGMA table_info(transactions)")}
         if not cols:
             return  # table absent entirely; executescript above will have made it
-        for name, ddl in (("tx_shape", "TEXT DEFAULT 'partial'"), ("outcome", "TEXT")):
+        # `status` is listed so it is RESTORED on a database that already ran
+        # the superseded renaming migration. CREATE TABLE IF NOT EXISTS cannot
+        # bring back a column that was renamed away, and without it a rollback
+        # to pre-#16 code fails with "no such column: status" — which
+        # _try_flush swallows by setting _enabled = False permanently, so the
+        # process keeps running and silently stops persisting everything. The
+        # rollback safety net this whole migration exists to provide would be
+        # missing on exactly the databases that most need it.
+        for name, ddl in (("status", "TEXT DEFAULT 'pending'"),
+                          ("tx_shape", "TEXT DEFAULT 'partial'"),
+                          ("outcome", "TEXT")):
             if name not in cols:
                 self.conn.execute(
                     f"ALTER TABLE transactions ADD COLUMN {name} {ddl}")
@@ -1189,9 +1209,12 @@ class TelemetryDB:
                 deleted = 0
                 self.conn.execute("BEGIN")
                 try:
-                    # events/flows/get_terminals all carry an index on
-                    # timestamp_ns, so the subquery seeks straight to the old
-                    # rows and the outer DELETE removes them by primary key.
+                    # events and flows carry an index on timestamp_ns, so their
+                    # subquery seeks straight to the old rows and the outer
+                    # DELETE removes them by primary key. get_terminals has no
+                    # such index (see SCHEMA_INDEXES) so its probe scans; that
+                    # is affordable only while retention keeps the table small,
+                    # and it is the cost that grows if GET volume rises.
                     for table in ("events", "flows", "get_terminals"):
                         cur = self.conn.execute(
                             f"DELETE FROM {table} WHERE id IN "

--- a/telemetry_db.py
+++ b/telemetry_db.py
@@ -196,7 +196,14 @@ SCHEMA_INDEXES = [
     "CREATE INDEX IF NOT EXISTS idx_txe_txid ON tx_events(tx_id)",
     "CREATE INDEX IF NOT EXISTS idx_txe_type_ts ON tx_events(event_type, timestamp_ns)",
     "CREATE INDEX IF NOT EXISTS idx_txe_peer_ts ON tx_events(peer_id, event_type, timestamp_ns)",
-    "CREATE INDEX IF NOT EXISTS idx_getterm_ts ON get_terminals(timestamp_ns)",
+    # get_terminals deliberately has NO index. Measured on a full 24h window
+    # (250k rows): the startup aggregate in get_terminal_buckets takes 382ms
+    # scanning and 799ms with an index on timestamp_ns — it groups the entire
+    # retention window, so a table scan beats index-ordered row lookups. The
+    # only query an index helps is prune's probe (65ms -> 22ms against a 5s
+    # budget). Adding one would also make correctness depend on an operator
+    # remembering to run create_indexes.py. The table is bounded by retention,
+    # so scanning is the right plan; revisit only if retention grows a lot.
     "CREATE INDEX IF NOT EXISTS idx_flows_ts ON flows(timestamp_ns)",
     "CREATE INDEX IF NOT EXISTS idx_flows_tx ON flows(tx_id) WHERE tx_id IS NOT NULL",
     "CREATE INDEX IF NOT EXISTS idx_flows_type_ts ON flows(event_type, timestamp_ns)",

--- a/telemetry_db.py
+++ b/telemetry_db.py
@@ -63,12 +63,28 @@ CREATE TABLE IF NOT EXISTS events (
 --   'settled' -- a genuine terminal event was seen; `outcome` says which
 --   'partial' -- events seen, but neither a start nor a terminal. Propagation
 --                events (update_broadcast_received and friends) land here.
--- `outcome` is the MEASURED result and is NULL unless tx_shape='settled'.
--- Success rates must be computed over `outcome`, which is NULL exactly when
--- nothing was measured, so the wrong query returns no rows rather than a
--- confident wrong number. This column pair replaced a single `status` column
--- whose 'complete' value was a fallback for "first event wasn't a start" —
--- see issue #15.
+--
+-- `outcome` is NULL unless tx_shape='settled', so a rate computed over it
+-- returns no rows rather than a confident wrong number when nothing was
+-- measured. What it means depends on the op, and the difference matters:
+--
+--   GET  -- CLIENT-FACING. Sourced from get_terminal, the only event the core
+--           emits at the client boundary. Safe to compute a success rate from,
+--           and the get_terminals table exists for exactly that.
+--   everything else -- HOP-OBSERVED. The core has no ClientTerminal analogue
+--           for SUBSCRIBE/PUT/UPDATE (see event_kind.rs: ClientTerminal is a
+--           GetEvent variant only), so their terminals are minted at each peer
+--           on the response path. One transaction can therefore produce several,
+--           and this column records the winner under TX_OUTCOME_PRECEDENCE in
+--           ws_server.py. It says "a terminal of this kind was observed
+--           somewhere on the path", NOT "this is what the client saw", and it
+--           MUST NOT be aggregated into a success rate — doing so weights by
+--           hop count, which is the exact defect issue #15 was filed about.
+--
+-- `status` is the superseded column, kept in place and untouched. Nothing
+-- writes it any more; it survives so a rollback to pre-#16 code still finds
+-- the column it expects. Read tx_shape/outcome instead. It can be dropped once
+-- rolling back that far is no longer a concern.
 CREATE TABLE IF NOT EXISTS transactions (
     tx_id TEXT PRIMARY KEY,
     op TEXT NOT NULL,
@@ -76,6 +92,7 @@ CREATE TABLE IF NOT EXISTS transactions (
     contract_short TEXT,
     start_ns INTEGER NOT NULL,
     end_ns INTEGER,
+    status TEXT DEFAULT 'pending',
     tx_shape TEXT DEFAULT 'partial',
     outcome TEXT,
     duration_ms REAL,
@@ -221,68 +238,55 @@ class TelemetryDB:
         self.conn.executescript(SCHEMA_TABLES)
         self._migrate()
 
-    # Bumped whenever SCHEMA_TABLES changes in a way an existing database has
-    # to be brought forward to. Stored in PRAGMA user_version.
-    SCHEMA_VERSION = 1
-
     def _migrate(self):
         """Bring an existing database up to the current schema.
 
-        CREATE TABLE IF NOT EXISTS silently leaves an older table alone, so
-        column changes need doing explicitly. The ALTER statements below are
-        metadata-only in SQLite (>= 3.25 for RENAME COLUMN), so they are
-        instant even on a 100+ GB database.
+        Purely additive: `status` is left in place and untouched, and the two
+        new columns are appended beside it. Nothing is renamed and no row is
+        rewritten, which has three consequences worth stating.
 
-        Gated on PRAGMA user_version so a restart costs one integer read: the
-        legacy rewrite below scans `transactions`, which has no index on the
-        old column and holds millions of rows.
+        It is effectively free. ADD COLUMN with a constant DEFAULT is
+        metadata-only in SQLite, so existing rows report the default without a
+        rewrite — measured at 0.011s against 2,931,393 rows, versus 7.1s for the
+        in-place rewrite this replaced.
+
+        It is reversible. Rolling back to pre-#16 code finds `status` exactly as
+        it left it. That matters more than it first appears: flush() batches
+        events, transactions, tx_events, flows and get_terminals into a single
+        transaction, and TelemetryDB._try_flush sets `_enabled = False`
+        permanently on error — so a missing column would abort the whole batch
+        and silently stop ALL dashboard ingest while the process looked healthy.
+
+        It loses nothing. Legacy rows keep their real terminal in `status` and
+        simply report tx_shape='partial' ("we have not classified this row"),
+        which is honest rather than lossy. Deriving tx_shape from `status` at
+        read time was considered and rejected: it would make a legacy row answer
+        'partial' to direct SQL and 'settled' to the dashboard API, and ad-hoc
+        SQL against this database is precisely how the #15 misdiagnosis
+        happened. It also avoids promoting per-hop GET verdicts — legacy
+        status='success' on a GET came from get_success, a per-hop event — into
+        a column documented as an outcome.
+
+        There is deliberately no PRAGMA user_version gate. The previous version
+        needed one to keep an expensive rewrite from re-running every restart;
+        with nothing expensive left, ADD COLUMN's own IF-absent check is the
+        cheaper and more honest guard, and a version counter that no migration
+        consults is a claim about ordering we would not be keeping.
         """
-        version = self.conn.execute("PRAGMA user_version").fetchone()[0]
-        if version >= self.SCHEMA_VERSION:
-            return
-
         cols = {row[1] for row in self.conn.execute("PRAGMA table_info(transactions)")}
+        if not cols:
+            return  # table absent entirely; executescript above will have made it
+        for name, ddl in (("tx_shape", "TEXT DEFAULT 'partial'"), ("outcome", "TEXT")):
+            if name not in cols:
+                self.conn.execute(
+                    f"ALTER TABLE transactions ADD COLUMN {name} {ddl}")
 
-        # issue #15: `status` conflated "we saw a terminal" with "we saw
-        # anything at all". Split into tx_shape (structure) + outcome (result).
-        if "status" in cols and "tx_shape" not in cols:
-            self.conn.execute(
-                "ALTER TABLE transactions RENAME COLUMN status TO tx_shape")
-        if "outcome" not in cols:
-            self.conn.execute("ALTER TABLE transactions ADD COLUMN outcome TEXT")
-
-        # Rewrite legacy values so the retention window isn't a mix of two
-        # vocabularies. 'success'/'not_found' were genuine measured terminals.
-        # 'complete' was the fallback and is NOT evidence of a terminal, so it
-        # degrades to 'partial' — we truly do not know what happened.
-        t0 = time.time()
-        cur = self.conn.execute("""
-            UPDATE transactions
-               SET outcome = CASE WHEN tx_shape IN ('success', 'not_found')
-                                  THEN tx_shape ELSE outcome END,
-                   tx_shape = CASE tx_shape
-                                  WHEN 'pending' THEN 'open'
-                                  WHEN 'success' THEN 'settled'
-                                  WHEN 'not_found' THEN 'settled'
-                                  ELSE 'partial'
-                              END
-             WHERE tx_shape IN ('pending', 'complete', 'success', 'not_found')
-        """)
-        if cur.rowcount > 0:
-            print(f"[db] migrated {cur.rowcount:,} legacy transaction rows to "
-                  f"tx_shape/outcome in {time.time() - t0:.1f}s", flush=True)
-        self.conn.execute(f"PRAGMA user_version = {self.SCHEMA_VERSION}")
-
-    def ensure_indexes(self):
-        """Create all indexes. Fast if they already exist, slow for new indexes
-        on large tables. Call from a background thread on large DBs."""
-        for stmt in SCHEMA_INDEXES:
-            idx_name = stmt.split("IF NOT EXISTS ")[1].split(" ON ")[0]
-            t0 = time.time()
-            self.conn.execute(stmt)
-            dt = time.time() - t0
-            if dt > 1.0:
-                print(f"[index] {idx_name} created in {dt:.1f}s", flush=True)
+    # There is deliberately no ensure_indexes() here. One existed with zero
+    # callers, which read as "indexes are created for you" — they are not, and
+    # calling it would have taken an exclusive write lock for 30+ minutes per
+    # new index on a 128 GB database, stalling live ingest. Indexes are created
+    # offline by create_indexes.py while the server is stopped; that script is
+    # the only sanctioned path. See the note in ws_server.main().
 
     def close(self):
         if self.conn:
@@ -593,7 +597,10 @@ class TelemetryDB:
     def get_terminal_buckets(self, since_ns, bucket_ns):
         """Aggregate client-facing GET outcomes into time buckets.
 
-        Returns rows of (bucket_ts, outcome, is_sub_op, count, median elapsed_ms).
+        Returns rows of (bucket_ts, outcome, is_sub_op, count, mean elapsed_ms).
+        The mean is not currently consumed — get_terminal reports elapsed_ms=0
+        on ~99.5% of successful direct GETs, so latency comes from the
+        get_request -> get_success delta instead.
         Reads the small get_terminals projection rather than the events table,
         which has no event_type index and is hundreds of GB.
         """

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -199,22 +199,65 @@ class TestTransactionRoundTrip:
 
 
 class TestGetTerminalsNeedsNoIndex:
-    """A deliberate decision, not an oversight.
+    """A deliberate decision, pinned structurally rather than by a benchmark.
 
-    get_terminals is bounded by retention (~250k rows), and its one aggregate
-    query groups the whole window — so it scans by design. Measured at that row
-    count the aggregate takes 382ms scanning versus 799ms with an index on
-    timestamp_ns. Adding one would slow the query it was meant to help AND make
-    correctness depend on an operator running create_indexes.py.
+    get_terminal_buckets is called with since_ns = METRICS_MAX_AGE_NS (8 days)
+    against a 24h retention, so its WHERE matches every row by construction,
+    and it GROUPs BY a computed bucket expression no timestamp_ns index can
+    serve. So an index cannot help the only query this table exists for, at any
+    row count — which a timing run alone would not establish.
     """
 
     def test_no_index_is_declared_for_get_terminals(self):
         from telemetry_db import SCHEMA_INDEXES
         assert not any("get_terminals" in stmt for stmt in SCHEMA_INDEXES), (
-            "an index here slows get_terminal_buckets and adds an operator step"
+            "an index cannot serve this table's only query and adds an "
+            "operator step; see the note in SCHEMA_INDEXES"
         )
 
-    def test_the_aggregate_works_without_one(self, tmp_path):
+    def test_the_metrics_window_is_wider_than_retention(self, tmp_path):
+        """Why the WHERE filters nothing: the lookback exceeds what is kept."""
+        import ws_server
+        from telemetry_db import DEFAULT_RETENTION_NS
+        assert ws_server.METRICS_MAX_AGE_NS > DEFAULT_RETENTION_NS
+
+        db = TelemetryDB(str(tmp_path / "t.db"))
+        db.open()
+        try:
+            now = time.time_ns()
+            for i in range(20):
+                db.insert_get_terminal(now - i * 3_600_000_000_000, f"t{i}", "p",
+                                       "c", "success", False, 0, 1, 1.0)
+            db.flush()
+            cut = now - ws_server.METRICS_MAX_AGE_NS
+            matched = db.conn.execute(
+                "SELECT COUNT(*) FROM get_terminals WHERE timestamp_ns > ?",
+                (cut,)).fetchone()[0]
+            total = db.conn.execute("SELECT COUNT(*) FROM get_terminals").fetchone()[0]
+            assert matched == total == 20, "the WHERE is not a filter in practice"
+        finally:
+            db.close()
+
+    def test_an_index_cannot_serve_the_group_by(self, tmp_path):
+        """The temp B-tree survives the index, so the index buys nothing."""
+        db = TelemetryDB(str(tmp_path / "t.db"))
+        db.open()
+        try:
+            db.conn.execute(
+                "CREATE INDEX idx_probe ON get_terminals(timestamp_ns)")
+            bucket = 4 * 3600 * 1_000_000_000
+            plan = [r[-1] for r in db.conn.execute(
+                "EXPLAIN QUERY PLAN "
+                f"SELECT (timestamp_ns/{bucket})*{bucket} AS b, outcome, is_sub_op, "
+                "COUNT(*), AVG(elapsed_ms) FROM get_terminals "
+                "WHERE timestamp_ns > ? GROUP BY b, outcome, is_sub_op", (0,))]
+            assert any("TEMP B-TREE" in step for step in plan), (
+                f"expected the GROUP BY to still need a temp B-tree, got {plan}"
+            )
+        finally:
+            db.close()
+
+    def test_the_aggregate_is_correct_without_an_index(self, tmp_path):
         db = TelemetryDB(str(tmp_path / "t.db"))
         db.open()
         try:
@@ -227,23 +270,66 @@ class TestGetTerminalsNeedsNoIndex:
             db.flush()
             rows = db.get_terminal_buckets(base - bucket, bucket)
             assert sum(r[3] for r in rows) == 50
+            assert {r[1] for r in rows} == {"success", "not_found"}
         finally:
             db.close()
 
-    def test_pruning_still_bounds_the_table(self, tmp_path):
-        """Without an index the scan cost is only acceptable while retention
-        keeps the table small, so pruning is what makes the choice safe."""
-        db = TelemetryDB(str(tmp_path / "t.db"))
+
+class TestMigrationRepairsADatabaseThatRanTheRenamingVersion:
+    """The superseded migration renamed `status` away. CREATE TABLE IF NOT
+    EXISTS cannot bring a renamed column back, so without an explicit repair a
+    rollback to pre-#16 code fails with "no such column: status" — and
+    _try_flush swallows that by disabling writes permanently, so the process
+    keeps running while persisting nothing.
+    """
+
+    def make_renamed_db(self, path):
+        """A database in the state #16's migration would have left it."""
+        conn = sqlite3.connect(path)
+        conn.executescript("""
+            CREATE TABLE transactions (
+                tx_id TEXT PRIMARY KEY, op TEXT NOT NULL, contract_key TEXT,
+                contract_short TEXT, start_ns INTEGER NOT NULL, end_ns INTEGER,
+                tx_shape TEXT DEFAULT 'partial', outcome TEXT, duration_ms REAL,
+                event_count INTEGER DEFAULT 0
+            );
+        """)
+        conn.execute("INSERT INTO transactions (tx_id, op, start_ns, tx_shape) "
+                     "VALUES ('t1', 'get', 1, 'settled')")
+        conn.commit()
+        conn.close()
+
+    def test_status_is_restored(self, tmp_path):
+        p = str(tmp_path / "renamed.db")
+        self.make_renamed_db(p)
+        db = TelemetryDB(p)
         db.open()
         try:
-            now = time.time_ns()
-            for i in range(10):
-                db.insert_get_terminal(now - 48 * 3600 * 1_000_000_000 + i,
-                                       f"old{i}", "p", "c", "success", False, 0, 1, 1.0)
-            db.insert_get_terminal(now, "new", "p", "c", "success", False, 0, 1, 1.0)
-            db.flush()
-            db.prune(retention_ns=24 * 3600 * 1_000_000_000)
-            left = [r[0] for r in db.conn.execute("SELECT tx_id FROM get_terminals")]
-            assert left == ["new"]
+            assert "status" in columns(db.conn, "transactions")
+        finally:
+            db.close()
+
+    def test_a_pre_16_writer_can_insert_again(self, tmp_path):
+        p = str(tmp_path / "renamed.db")
+        self.make_renamed_db(p)
+        db = TelemetryDB(p)
+        db.open()
+        try:
+            db.conn.execute(
+                "INSERT INTO transactions (tx_id, op, contract_key, contract_short, "
+                "start_ns, end_ns, status, duration_ms, event_count) "
+                "VALUES ('old', 'get', NULL, NULL, 1, 2, 'pending', 1.0, 1)")
+        finally:
+            db.close()
+
+    def test_existing_new_style_rows_are_untouched(self, tmp_path):
+        p = str(tmp_path / "renamed.db")
+        self.make_renamed_db(p)
+        db = TelemetryDB(p)
+        db.open()
+        try:
+            assert db.conn.execute(
+                "SELECT tx_shape FROM transactions WHERE tx_id='t1'"
+            ).fetchone()[0] == "settled"
         finally:
             db.close()

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -9,7 +9,23 @@ def columns(conn, table):
     return {r[1] for r in conn.execute(f"PRAGMA table_info({table})")}
 
 
-class TestMigrationFromTheOldStatusColumn:
+class TestAdditiveOnlyMigration:
+    """issue #15 follow-up: the migration is purely additive.
+
+    `status` is left in place and untouched, the two new columns are appended
+    beside it, and no row is rewritten. That keeps a rollback to pre-#16 code
+    working, which matters because flush() batches every table into one
+    transaction and _try_flush disables the DB permanently on error — a missing
+    column would silently stop ALL ingest, not just transactions.
+    """
+
+    LEGACY_ROWS = [
+        ("t1", "update", "complete"),    # phantom, minted by a propagation event
+        ("t2", "subscribe", "pending"),  # never settled: wrong terminal name
+        ("t3", "get", "success"),        # per-HOP verdict, not a client outcome
+        ("t4", "get", "not_found"),      # per-HOP verdict, not a client outcome
+    ]
+
     def make_legacy_db(self, path):
         conn = sqlite3.connect(path)
         conn.executescript("""
@@ -20,31 +36,49 @@ class TestMigrationFromTheOldStatusColumn:
                 event_count INTEGER DEFAULT 0
             );
         """)
-        rows = [
-            ("t1", "update", "complete"),   # phantom: propagation event
-            ("t2", "subscribe", "pending"),  # never settled, wrong terminal name
-            ("t3", "get", "success"),        # genuinely measured
-            ("t4", "get", "not_found"),      # genuinely measured
-        ]
         conn.executemany(
             "INSERT INTO transactions (tx_id, op, start_ns, status) VALUES (?, ?, 1, ?)",
-            rows)
+            self.LEGACY_ROWS)
         conn.commit()
         conn.close()
 
-    def test_status_is_renamed_and_outcome_added(self, tmp_path):
+    def test_status_survives_so_a_rollback_still_works(self, tmp_path):
         p = str(tmp_path / "legacy.db")
         self.make_legacy_db(p)
         db = TelemetryDB(p)
         db.open()
         try:
             cols = columns(db.conn, "transactions")
-            assert "status" not in cols, "the misleading column name must be gone"
+            assert "status" in cols, "dropping `status` breaks rollback to pre-#16 code"
             assert {"tx_shape", "outcome"} <= cols
+            # An old writer's INSERT names `status` explicitly; it must still work.
+            db.conn.execute(
+                "INSERT INTO transactions (tx_id, op, contract_key, contract_short, "
+                "start_ns, end_ns, status, duration_ms, event_count) "
+                "VALUES ('old', 'get', NULL, NULL, 1, 2, 'pending', 1.0, 1)")
         finally:
             db.close()
 
-    def test_legacy_values_are_reinterpreted_honestly(self, tmp_path):
+    def test_no_legacy_row_is_rewritten(self, tmp_path):
+        p = str(tmp_path / "legacy.db")
+        self.make_legacy_db(p)
+        db = TelemetryDB(p)
+        db.open()
+        try:
+            got = dict(db.conn.execute("SELECT tx_id, status FROM transactions"))
+        finally:
+            db.close()
+        assert got == {t: s for t, _, s in self.LEGACY_ROWS}, \
+            "legacy values must be preserved, not reinterpreted in place"
+
+    def test_legacy_rows_report_unclassified_not_a_fabricated_outcome(self, tmp_path):
+        """`partial` honestly means "we have not classified this row".
+
+        t3/t4 matter most: their legacy `status` came from get_success /
+        get_not_found, which are per-HOP. Promoting those into `outcome` would
+        put a relay's local verdict into a column documented as a client-facing
+        result — the very confusion issue #15 is about.
+        """
         p = str(tmp_path / "legacy.db")
         self.make_legacy_db(p)
         db = TelemetryDB(p)
@@ -52,48 +86,13 @@ class TestMigrationFromTheOldStatusColumn:
         try:
             got = dict(
                 (r[0], (r[1], r[2]))
-                for r in db.conn.execute("SELECT tx_id, tx_shape, outcome FROM transactions")
+                for r in db.conn.execute(
+                    "SELECT tx_id, tx_shape, outcome FROM transactions")
             )
         finally:
             db.close()
-        # 'complete' was never evidence of a terminal, so it degrades to partial
-        # rather than being promoted to a settled result.
-        assert got["t1"] == ("partial", None)
-        assert got["t2"] == ("open", None)
-        assert got["t3"] == ("settled", "success")
-        assert got["t4"] == ("settled", "not_found")
-
-    def test_migration_runs_once_and_is_recorded(self, tmp_path):
-        """The legacy rewrite scans a table with millions of rows, so it must
-        not run again on every restart."""
-        p = str(tmp_path / "legacy.db")
-        self.make_legacy_db(p)
-        db = TelemetryDB(p)
-        db.open()
-        try:
-            assert db.conn.execute("PRAGMA user_version").fetchone()[0] == \
-                TelemetryDB.SCHEMA_VERSION
-        finally:
-            db.close()
-
-        # Plant a value the migration WOULD rewrite. If it survives the next
-        # open, the rewrite genuinely did not run again. (A sentinel the
-        # migration ignores would survive either way and prove nothing.)
-        db = TelemetryDB(p)
-        db.open()
-        try:
-            db.conn.execute(
-                "UPDATE transactions SET tx_shape = 'complete' WHERE tx_id = 't1'")
-        finally:
-            db.close()
-        db = TelemetryDB(p)
-        db.open()
-        try:
-            shape = db.conn.execute(
-                "SELECT tx_shape FROM transactions WHERE tx_id='t1'").fetchone()[0]
-            assert shape == "complete", "migration re-ran after it was recorded"
-        finally:
-            db.close()
+        for tx_id in ("t1", "t2", "t3", "t4"):
+            assert got[tx_id] == ("partial", None), tx_id
 
     def test_migration_is_idempotent(self, tmp_path):
         p = str(tmp_path / "legacy.db")
@@ -105,25 +104,37 @@ class TestMigrationFromTheOldStatusColumn:
         db = TelemetryDB(p)
         db.open()
         try:
-            assert columns(db.conn, "transactions") >= {"tx_shape", "outcome"}
-            n = db.conn.execute(
-                "SELECT COUNT(*) FROM transactions WHERE tx_shape IN "
-                "('pending','complete','success','not_found')").fetchone()[0]
-            assert n == 0
+            assert columns(db.conn, "transactions") >= {"status", "tx_shape", "outcome"}
+            assert dict(db.conn.execute("SELECT tx_id, status FROM transactions")) == \
+                {t: s for t, _, s in self.LEGACY_ROWS}
         finally:
             db.close()
 
-    def test_fresh_database_has_the_new_schema(self, tmp_path):
+    def test_new_writes_use_the_new_columns_only(self, tmp_path):
+        """Nothing writes `status` any more; it is inert, not dual-written."""
+        p = str(tmp_path / "legacy.db")
+        self.make_legacy_db(p)
+        db = TelemetryDB(p)
+        db.open()
+        try:
+            db.upsert_transaction("new", "get", None, None, 1, 2,
+                                  "settled", "success", 1.0, 2)
+            db.flush()
+            row = db.conn.execute(
+                "SELECT status, tx_shape, outcome FROM transactions WHERE tx_id='new'"
+            ).fetchone()
+            assert row == ("pending", "settled", "success")
+        finally:
+            db.close()
+
+    def test_fresh_database_has_every_table_and_column(self, tmp_path):
         db = TelemetryDB(str(tmp_path / "fresh.db"))
         db.open()
         try:
-            cols = columns(db.conn, "transactions")
-            assert "status" not in cols
-            assert {"tx_shape", "outcome"} <= cols
-            assert "get_terminals" in {
-                r[0] for r in db.conn.execute(
-                    "SELECT name FROM sqlite_master WHERE type='table'")
-            }
+            assert {"status", "tx_shape", "outcome"} <= columns(db.conn, "transactions")
+            tables = {r[0] for r in db.conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'")}
+            assert "get_terminals" in tables
         finally:
             db.close()
 

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -196,3 +196,54 @@ class TestTransactionRoundTrip:
             assert "status" not in got["tx1"]
         finally:
             db.close()
+
+
+class TestGetTerminalsNeedsNoIndex:
+    """A deliberate decision, not an oversight.
+
+    get_terminals is bounded by retention (~250k rows), and its one aggregate
+    query groups the whole window — so it scans by design. Measured at that row
+    count the aggregate takes 382ms scanning versus 799ms with an index on
+    timestamp_ns. Adding one would slow the query it was meant to help AND make
+    correctness depend on an operator running create_indexes.py.
+    """
+
+    def test_no_index_is_declared_for_get_terminals(self):
+        from telemetry_db import SCHEMA_INDEXES
+        assert not any("get_terminals" in stmt for stmt in SCHEMA_INDEXES), (
+            "an index here slows get_terminal_buckets and adds an operator step"
+        )
+
+    def test_the_aggregate_works_without_one(self, tmp_path):
+        db = TelemetryDB(str(tmp_path / "t.db"))
+        db.open()
+        try:
+            bucket = 4 * 3600 * 1_000_000_000
+            base = (time.time_ns() // bucket) * bucket + 1_000_000
+            for i in range(50):
+                db.insert_get_terminal(base + i, f"tx{i}", "p", "c",
+                                       "success" if i % 2 else "not_found",
+                                       i % 3 == 0, 0, 2, 5.0)
+            db.flush()
+            rows = db.get_terminal_buckets(base - bucket, bucket)
+            assert sum(r[3] for r in rows) == 50
+        finally:
+            db.close()
+
+    def test_pruning_still_bounds_the_table(self, tmp_path):
+        """Without an index the scan cost is only acceptable while retention
+        keeps the table small, so pruning is what makes the choice safe."""
+        db = TelemetryDB(str(tmp_path / "t.db"))
+        db.open()
+        try:
+            now = time.time_ns()
+            for i in range(10):
+                db.insert_get_terminal(now - 48 * 3600 * 1_000_000_000 + i,
+                                       f"old{i}", "p", "c", "success", False, 0, 1, 1.0)
+            db.insert_get_terminal(now, "new", "p", "c", "success", False, 0, 1, 1.0)
+            db.flush()
+            db.prune(retention_ns=24 * 3600 * 1_000_000_000)
+            left = [r[0] for r in db.conn.execute("SELECT tx_id FROM get_terminals")]
+            assert left == ["new"]
+        finally:
+            db.close()

--- a/tests/test_get_health_metrics.py
+++ b/tests/test_get_health_metrics.py
@@ -179,10 +179,19 @@ class TestOperationStatsPanel:
         assert series_of(srv)["get_rate"] == 100.0
 
 
-class TestSubscribeStatsAreNoLongerPinnedAtZero:
-    def test_subscribe_success_is_counted(self, srv):
-        """op_stats and sub_ok both keyed on `subscribed`, which is never
-        emitted, so every subscribe counter read zero."""
+class TestSubscribeHasNoSuccessRate:
+    """issue #15 follow-up: SUBSCRIBE has no client-facing terminal event.
+
+    The core emits GetEvent::ClientTerminal at the client boundary, but there is
+    no equivalent on SubscribeEvent. subscribe_success is minted at every peer
+    on the response path (register.rs, on SubscribeMsg::Response, with the
+    comment noting hop_count is "preserved by relays bubbling up"), so a 4-hop
+    subscribe emits four. Their ratio therefore weights by hop count — the same
+    defect that made GET read 0.05% against a real 87%. No arithmetic fixes it,
+    so the counts ship without a rate.
+    """
+
+    def test_no_subscribe_success_rate_is_published(self, srv):
         t = time.time_ns()
         for i in range(8):
             feed(srv, "subscribe_request", t + i, tx_id=f"s-{i}")
@@ -192,18 +201,103 @@ class TestSubscribeStatsAreNoLongerPinnedAtZero:
             feed(srv, "subscribe_not_found", t + 200 + i, tx_id=f"s-{6 + i}")
 
         stats = srv.get_operation_stats()["subscribe"]
-        assert stats["total"] == 8
-        assert stats["success_rate"] == 75.0
-        assert stats["not_found"] == 2
-        assert series_of(srv)["sub_n"] == 8
-        assert series_of(srv)["sub_rate"] == 75.0
+        assert "success_rate" not in stats, (
+            "a rate over per-hop counters is issue #15 with a new name"
+        )
+        assert "sub_rate" not in series_of(srv)
 
-    def test_subscribe_timeout_counts_as_a_failure(self, srv):
+    def test_counters_are_named_so_they_cannot_be_read_as_outcomes(self, srv):
         t = time.time_ns()
-        for i in range(5):
-            feed(srv, "subscribe_success", t + i, tx_id=f"s-{i}")
-        for i in range(5):
-            feed(srv, "subscribe_timeout", t + 100 + i, tx_id=f"t-{i}")
+        for i in range(8):
+            feed(srv, "subscribe_request", t + i, tx_id=f"s-{i}")
+        for i in range(6):
+            feed(srv, "subscribe_success", t + 100 + i, tx_id=f"s-{i}")
+        for i in range(2):
+            feed(srv, "subscribe_not_found", t + 200 + i, tx_id=f"s-{6 + i}")
+        feed(srv, "subscribe_timeout", t + 300, tx_id="s-9")
+
         stats = srv.get_operation_stats()["subscribe"]
-        assert stats["timeouts"] == 5
-        assert stats["success_rate"] == 50.0
+        assert stats == {
+            "hop_requests": 8, "hop_successes": 6,
+            "hop_not_found": 2, "hop_timeouts": 1,
+        }
+        # Every exposed key must carry the hop caveat in its name.
+        assert all(k.startswith("hop_") for k in stats)
+
+    def test_hop_counts_are_still_reported_in_the_series(self, srv):
+        t = time.time_ns()
+        for i in range(6):
+            feed(srv, "subscribe_success", t + i, tx_id=f"s-{i}")
+        for i in range(2):
+            feed(srv, "subscribe_not_found", t + 100 + i, tx_id=f"n-{i}")
+        point = series_of(srv)
+        assert point["sub_hops_ok"] == 6
+        assert point["sub_hops_bad"] == 2
+
+    def test_subscribe_events_are_still_counted_at_all(self, srv):
+        """The original defect was counters pinned at zero because they keyed
+        on `subscribed`, which the core never emits. Dropping the rate must not
+        reintroduce that."""
+        t = time.time_ns()
+        for i in range(6):
+            feed(srv, "subscribe_success", t + i, tx_id=f"s-{i}")
+        assert srv.get_operation_stats()["subscribe"]["hop_successes"] == 6
+
+
+class TestPrecomputeRebuildsEveryOutcome:
+    """The post-restart path rebuilds what the dashboard shows most of the time.
+
+    Mutating `ok = outcome == "success"` to `ok = True` in
+    precompute_metrics_from_db survived the whole suite, because every existing
+    test fed it only outcome='success' at is_sub_op=0.
+    """
+
+    def feed_and_rebuild(self, srv, samples):
+        t = time.time_ns()
+        for i, (outcome, sub) in enumerate(samples):
+            feed(srv, "get_terminal", t + i, tx_id=f"g-{i}",
+                 outcome=outcome, is_sub_op=sub)
+        srv.db.flush()
+        srv.metrics_buckets.clear()
+        srv._current_bucket = None
+        srv.precompute_metrics_from_db()
+        return srv.get_metrics_timeseries()["series"][-1]
+
+    def test_rebuild_distinguishes_success_from_failure(self, srv):
+        point = self.feed_and_rebuild(srv, (
+            [("success", False)] * 7
+            + [("not_found", False)] * 2
+            + [("timeout_exhausted", False)] * 1
+        ))
+        assert point["get_rate"] == 70.0, "non-success outcomes were counted as success"
+        assert point["get_n"] == 10
+
+    def test_rebuild_keeps_sub_ops_separate(self, srv):
+        point = self.feed_and_rebuild(srv, (
+            [("success", False)] * 6
+            + [("timeout_exhausted", True)] * 8
+            + [("success", True)] * 2
+        ))
+        assert point["get_rate"] == 100.0, "direct GETs were healthy"
+        assert point["get_sub_rate"] == 20.0, "sub-op failures must survive a restart"
+        assert point["get_n"] == 6
+        assert point["get_sub_n"] == 10
+
+    def test_rebuild_matches_the_live_path(self, srv):
+        """Whatever the restart shows must equal what was shown before it."""
+        samples = ([("success", False)] * 5 + [("not_found", False)] * 3
+                   + [("success", True)] * 4 + [("timeout_exhausted", True)] * 6)
+        t = time.time_ns()
+        for i, (outcome, sub) in enumerate(samples):
+            feed(srv, "get_terminal", t + i, tx_id=f"g-{i}",
+                 outcome=outcome, is_sub_op=sub)
+        live = srv.get_metrics_timeseries()["series"][-1]
+
+        srv.db.flush()
+        srv.metrics_buckets.clear()
+        srv._current_bucket = None
+        srv.precompute_metrics_from_db()
+        rebuilt = srv.get_metrics_timeseries()["series"][-1]
+
+        for key in ("get_rate", "get_sub_rate", "get_n", "get_sub_n"):
+            assert live[key] == rebuilt[key], f"{key} changed across a restart"

--- a/tests/test_server_client_agreement.py
+++ b/tests/test_server_client_agreement.py
@@ -5,8 +5,11 @@ tables. They are the two halves of the same fix, and a change to one that
 misses the other silently reintroduces the drift issue #15 is about.
 """
 import ast
+import json
 import os
 import re
+import shutil
+import subprocess
 
 import pytest
 
@@ -125,3 +128,160 @@ class TestTheClientNoLongerCarriesTheOldSemantics:
         js = parse_js_object("TX_TERMINAL_EVENTS")
         assert "get_success" not in js
         assert "get_not_found" not in js
+
+
+# ── The resolution rule, not just the classification tables ────────────────
+#
+# The agreement test above compares how each side CLASSIFIES an event. It
+# cannot see how each side RESOLVES two terminals landing on the same
+# transaction, which is a separate rule that must also match — the server
+# gained precedence while the client was still last-write-wins, and nothing
+# here could tell.
+#
+# These drive the REAL js/events.js through node rather than reimplementing or
+# parsing it, so the comparison is against shipped behaviour.
+
+NODE = shutil.which("node")
+
+OUTCOMES = ["success", "not_found", "timeout_exhausted", "timeout",
+            "rejected", "failure", "disconnected", "something_unknown", None]
+EVENTS = ["get_terminal", "subscribe_success", "subscribe_not_found",
+          "subscribe_timeout", "put_success", "connect_rejected", "disconnect"]
+
+
+def js_outcome_wins_matrix(cases):
+    """Evaluate outcomeWins() in js/events.js over `cases` via node."""
+    script = os.path.join(os.path.dirname(JS), "..",
+                          "_agreement_probe.mjs")
+    script = os.path.abspath(script)
+    payload = json.dumps(cases)
+    with open(script, "w", encoding="utf-8") as f:
+        f.write(
+            f"import {{ outcomeWins }} from {json.dumps(JS)};\n"
+            f"const cases = {payload};\n"
+            "console.log(JSON.stringify(cases.map("
+            "c => outcomeWins(c[0], c[1], c[2], c[3]))));\n"
+        )
+    try:
+        out = subprocess.run([NODE, script], capture_output=True, text=True,
+                             check=True, timeout=60).stdout
+    finally:
+        os.unlink(script)
+    return json.loads(out)
+
+
+@pytest.mark.skipif(NODE is None, reason="node not available")
+def test_resolution_rule_agrees_across_every_combination():
+    cases = [[no, ne, oo, oe]
+             for no in OUTCOMES for ne in EVENTS
+             for oo in OUTCOMES for oe in EVENTS]
+    js = js_outcome_wins_matrix(cases)
+    mismatches = [
+        (c, j) for c, j in zip(cases, js)
+        if ws_server.outcome_wins(c[0], c[1], c[2], c[3]) is not j
+    ]
+    assert not mismatches, (
+        f"{len(mismatches)} of {len(cases)} disagree, e.g. {mismatches[:3]}"
+    )
+
+
+@pytest.mark.skipif(NODE is None, reason="node not available")
+def test_the_matrix_actually_exercises_both_answers():
+    """Guards the test above from passing because everything returned True."""
+    cases = [[no, ne, oo, oe]
+             for no in OUTCOMES for ne in EVENTS
+             for oo in OUTCOMES for oe in EVENTS]
+    js = js_outcome_wins_matrix(cases)
+    assert {True, False} <= set(js), "the matrix is one-sided and proves nothing"
+
+
+def test_precedence_tables_match():
+    js = parse_js_object("TX_OUTCOME_PRECEDENCE")
+    assert js == ws_server.TX_OUTCOME_PRECEDENCE
+
+
+def js_track(sequences):
+    """Drive the REAL trackTransactionFromEvent in js/events.js via node.
+
+    Testing outcomeWins() alone is not enough: the client can agree on the rule
+    and still not apply it at the call site, which is exactly how it stayed
+    last-write-wins while the server had precedence.
+    """
+    script = os.path.abspath(os.path.join(os.path.dirname(JS), "..",
+                                          "_track_probe.mjs"))
+    state_js = json.dumps(os.path.join(os.path.dirname(JS), "state.js"))
+    with open(script, "w", encoding="utf-8") as f:
+        f.write(
+            f"import {{ state }} from {state_js};\n"
+            f"import {{ trackTransactionFromEvent }} from {json.dumps(JS)};\n"
+            f"const seqs = {json.dumps(sequences)};\n"
+            "const out = seqs.map(seq => {\n"
+            "  state.allTransactions = []; state.transactionMap = new Map();\n"
+            "  seq.forEach(([t, ts, outcome], i) => trackTransactionFromEvent(\n"
+            "    { tx_id: 'tx', event_type: t, timestamp: ts, peer_id: 'p',\n"
+            "      ...(outcome ? { outcome } : {}) }));\n"
+            "  const tx = state.allTransactions[0];\n"
+            "  return tx ? { tx_shape: tx.tx_shape, outcome: tx.outcome } : null;\n"
+            "});\n"
+            "console.log(JSON.stringify(out));\n"
+        )
+    try:
+        out = subprocess.run([NODE, script], capture_output=True, text=True,
+                             check=True, timeout=60).stdout
+    finally:
+        os.unlink(script)
+    return json.loads(out)
+
+
+def py_track(srv_mod, seq):
+    srv_mod.transactions.clear()
+    srv_mod.transaction_order.clear()
+    for event_type, ts, outcome in seq:
+        srv_mod.track_transaction("tx", event_type, ts, "p",
+                                  terminal_outcome=outcome)
+    tx = srv_mod.transactions.get("tx")
+    return {"tx_shape": tx["tx_shape"], "outcome": tx["outcome"]} if tx else None
+
+
+TRACK_SEQUENCES = [
+    # Contradictory hop terminals, both arrival orders.
+    [["subscribe_request", 100, None], ["subscribe_not_found", 200, None],
+     ["subscribe_success", 300, None]],
+    [["subscribe_request", 100, None], ["subscribe_success", 200, None],
+     ["subscribe_not_found", 300, None]],
+    # A client-facing terminal that ranks LOWER than the hop terminal already
+    # recorded: only the authority rule overturns it.
+    [["subscribe_request", 100, None], ["subscribe_success", 200, None],
+     ["get_terminal", 300, "not_found"]],
+    # ...and a hop terminal that ranks higher arriving after a client one.
+    [["get_request", 100, None], ["get_terminal", 200, "not_found"],
+     ["subscribe_success", 300, None]],
+    # A late per-hop start must not reopen a settled transaction.
+    [["get_request", 100, None], ["get_terminal", 200, "success"],
+     ["get_request", 300, None]],
+    # Repeated identical hop terminals stay stable.
+    [["subscribe_request", 100, None], ["subscribe_success", 200, None],
+     ["subscribe_success", 300, None], ["subscribe_success", 400, None]],
+    # Propagation only: partial, no fabricated outcome.
+    [["update_broadcast_received", 100, None]],
+]
+
+
+@pytest.mark.skipif(NODE is None, reason="node not available")
+def test_the_client_applies_the_resolution_rule_not_just_defines_it():
+    js = js_track(TRACK_SEQUENCES)
+    py = [py_track(ws_server, seq) for seq in TRACK_SEQUENCES]
+    mismatches = [(s, j, p) for s, j, p in zip(TRACK_SEQUENCES, js, py) if j != p]
+    assert not mismatches, (
+        "client and server disagree on the settled state of the same event "
+        f"stream: {mismatches}"
+    )
+
+
+@pytest.mark.skipif(NODE is None, reason="node not available")
+def test_the_sequences_actually_discriminate():
+    """Guards the test above: the fixtures must produce more than one answer,
+    or agreement would be trivial."""
+    js = js_track(TRACK_SEQUENCES)
+    assert len({(r or {}).get("outcome") for r in js}) > 1
+    assert len({(r or {}).get("tx_shape") for r in js}) > 1

--- a/tests/test_server_client_agreement.py
+++ b/tests/test_server_client_agreement.py
@@ -53,26 +53,60 @@ def test_terminal_events_match():
     assert js == py
 
 
-@pytest.mark.parametrize("event_type", [
-    "get_request", "get_success", "get_not_found", "get_terminal",
-    "subscribe_request", "subscribe_success", "subscribe_not_found",
-    "subscribe_timeout", "subscribed",
-    "put_request", "put_success", "update_request", "update_success",
-    "update_broadcast_received", "connect_connected", "disconnect",
-])
-def test_classification_agrees_for_every_event_the_dashboard_sees(event_type):
-    """Cross-check the Python classifier against the JS tables."""
-    op, role = ws_server.classify_tx_event(event_type)
+def js_classify(event_type):
+    """Evaluate js/events.js's classifyTxEvent fallback chain in Python.
+
+    Parsed out of the source rather than reimplemented, so the two cannot drift
+    without this failing.
+    """
     js_start = parse_js_object("TX_START_EVENTS")
     js_terminal = parse_js_object("TX_TERMINAL_EVENTS")
     if event_type in js_start:
-        assert (op, role) == (js_start[event_type], "start")
-    elif event_type in js_terminal:
-        assert (op, role) == (js_terminal[event_type][0], "terminal")
-    elif event_type == "get_terminal":
-        assert (op, role) == ("get", "terminal")
-    else:
-        assert role is None
+        return js_start[event_type], "start"
+    if event_type in js_terminal:
+        return js_terminal[event_type][0], "terminal"
+    src = js_source()
+    body = re.search(r"export function classifyTxEvent\(eventType\) \{(.*?)\n\}",
+                     src, re.S).group(1)
+    for line in body.splitlines():
+        m = re.search(
+            r"if \((.*?)\) return \{ op: '([a-z]+)', role: (null|'[a-z]+') \};", line)
+        if not m:
+            continue
+        cond, op, role = m.group(1), m.group(2), m.group(3)
+        role = None if role == "null" else role.strip("'")
+        for pat in re.findall(r"eventType\.startsWith\('([^']+)'\)", cond):
+            if event_type.startswith(pat):
+                return op, role
+        for pat in re.findall(r"eventType\.includes\('([^']+)'\)", cond):
+            if pat in event_type:
+                return op, role
+        for lit in re.findall(r"eventType === '([^']+)'", cond):
+            if event_type == lit:
+                return op, role
+    return event_type.split("_")[0] or "other", None
+
+
+@pytest.mark.parametrize("event_type", [
+    "get_request", "get_success", "get_not_found", "get_terminal",
+    "subscribe_request", "subscribe_success", "subscribe_not_found",
+    "subscribe_timeout", "subscribed", "unsubscribed",
+    "put_request", "put_success", "put_failure",
+    "update_request", "update_success", "update_failure",
+    "update_broadcast_received", "update_broadcast_applied", "broadcast_emitted",
+    "connect_connected", "connect_rejected", "connect_request_sent", "disconnect",
+    "seeding_started", "peer_startup", "transfer_completed", "hosting_started",
+])
+def test_classification_agrees_for_every_event_the_dashboard_sees(event_type):
+    """Compare BOTH op and role.
+
+    Asserting only `role is None` for anything outside the two tables left the
+    test structurally blind to op-level drift, and a fix that touched only the
+    Python side went unnoticed because of it: `unsubscribed` classified as
+    'unsubscribed' on the server and 'subscribe' in the client, which decides
+    whether the event creates a transaction at all.
+    """
+    assert ws_server.classify_tx_event(event_type) == js_classify(event_type)
 
 
 class TestTheClientNoLongerCarriesTheOldSemantics:

--- a/tests/test_transaction_payloads.py
+++ b/tests/test_transaction_payloads.py
@@ -14,22 +14,46 @@ import ws_server
 from conftest import make_record
 
 
-class TestBackfillMatchesTheServer:
-    def test_start_events_agree(self):
-        assert backfill_db.TX_START_EVENTS == set(ws_server.TX_START_EVENTS)
+class TestBackfillSharesTheServersDefinitions:
+    """backfill_db.py writes the same tables by an independent path.
 
-    def test_terminal_events_and_outcomes_agree(self):
-        server = {k: v[1] for k, v in ws_server.TX_TERMINAL_EVENTS.items()}
-        assert backfill_db.TX_TERMINAL_EVENTS == server
+    It used to keep its own transcription of the classification tables and
+    drifted twice: keying subscribes off `subscribed` (never emitted) and
+    recording get_not_found as "success". It now imports them, so drift is
+    unrepresentable rather than merely tested for.
+    """
+
+    def test_tables_are_the_servers_own(self):
+        assert backfill_db.TX_START_EVENTS == set(ws_server.TX_START_EVENTS)
+        assert backfill_db.TX_TERMINAL_EVENTS == \
+            {k: v[1] for k, v in ws_server.TX_TERMINAL_EVENTS.items()}
+        assert backfill_db.outcome_wins is ws_server.outcome_wins
+
+    def test_schema_is_the_servers_own(self):
+        """The hand-copied DDL silently omitted get_terminals, so a rebuilt
+        database produced a chart with both GET lines blank."""
+        import inspect
+        import telemetry_db
+        src = inspect.getsource(backfill_db.main)
+        assert "executescript(SCHEMA_TABLES)" in src
+        assert "CREATE TABLE events" not in src, "schema was re-transcribed"
+        assert "get_terminals" in telemetry_db.SCHEMA_TABLES
 
     def test_backfill_does_not_settle_on_per_hop_get_events(self):
-        """It used to mark get_not_found as 'success' outright."""
         assert "get_success" not in backfill_db.TX_TERMINAL_EVENTS
         assert "get_not_found" not in backfill_db.TX_TERMINAL_EVENTS
 
     def test_backfill_stores_the_client_facing_get_event(self):
         assert "get_terminal" in backfill_db.HISTORY_EVENT_TYPES
         assert "subscribe_timeout" in backfill_db.HISTORY_EVENT_TYPES
+
+    def test_backfill_populates_get_terminals(self):
+        """Without this the documented recovery path restores PUT and UPDATE
+        and leaves both GET lines blank — the metric this work exists to fix."""
+        import inspect
+        src = inspect.getsource(backfill_db.main)
+        assert "INSERT INTO get_terminals" in src
+        assert "getterm_buf.append" in src
 
 
 class TestLiveAndHistoryPayloadsAgree:

--- a/tests/test_transaction_shape.py
+++ b/tests/test_transaction_shape.py
@@ -155,3 +155,74 @@ class TestInvariants:
         shapes = {tx["tx_shape"] for tx in srv.transactions.values()}
         assert "complete" not in shapes
         assert "pending" not in shapes
+
+
+class TestLateHopEventsDoNotDemoteASettledTransaction:
+    """`get_request` is per-HOP, so a relay's request can legitimately arrive
+    after the originator's terminal. Dropping the `tx_shape == "partial"` guard
+    survived the whole suite, yet it lets a late start flip a settled
+    transaction back to 'open' while leaving its outcome in place — which
+    violates the invariant that an outcome implies settled."""
+
+    def test_a_late_start_does_not_reopen_a_settled_transaction(self, srv):
+        track(srv, "get_request", "tx-1", ts=100)
+        track(srv, "get_terminal", "tx-1", ts=200, terminal_outcome="success")
+        tx = track(srv, "get_request", "tx-1", ts=300)
+        assert tx["tx_shape"] == "settled", "a late per-hop request reopened a settled tx"
+        assert tx["outcome"] == "success"
+
+    def test_the_invariant_holds_under_reordering(self, srv):
+        for i, et in enumerate(["get_terminal", "get_request", "get_request"]):
+            srv.track_transaction("tx-2", et, 100 + i, "peer-a",
+                                  terminal_outcome="not_found" if et == "get_terminal" else None)
+        tx = srv.transactions["tx-2"]
+        assert tx["outcome"] is None or tx["tx_shape"] == "settled"
+
+    @pytest.mark.parametrize("start_event", ["subscribe_request", "put_request",
+                                             "update_request"])
+    def test_holds_for_every_op(self, srv, start_event):
+        op = start_event.split("_")[0]
+        terminal = {"subscribe": "subscribe_success", "put": "put_success",
+                    "update": "update_success"}[op]
+        track(srv, start_event, "tx-3", ts=100)
+        track(srv, terminal, "tx-3", ts=200)
+        tx = track(srv, start_event, "tx-3", ts=300)
+        assert tx["tx_shape"] == "settled"
+
+
+class TestContradictoryTerminalsAreResolvedDeterministically:
+    """SUBSCRIBE/PUT/UPDATE terminals are minted per hop, and one client
+    subscribe can emit both subscribe_not_found and subscribe_success. Under
+    last-write-wins the stored outcome depended on collector ingest order."""
+
+    def test_success_wins_regardless_of_arrival_order(self, srv):
+        track(srv, "subscribe_request", "tx-a", ts=100)
+        track(srv, "subscribe_not_found", "tx-a", ts=200)
+        tx = track(srv, "subscribe_success", "tx-a", ts=300)
+        assert tx["outcome"] == "success"
+
+        track(srv, "subscribe_request", "tx-b", ts=100)
+        track(srv, "subscribe_success", "tx-b", ts=200)
+        tx = track(srv, "subscribe_not_found", "tx-b", ts=300)
+        assert tx["outcome"] == "success", "outcome depended on ingest order"
+
+    def test_repeated_hop_terminals_are_stable(self, srv):
+        track(srv, "subscribe_request", "tx-c", ts=100)
+        for i in range(4):  # a 4-hop subscribe emits four
+            track(srv, "subscribe_success", "tx-c", ts=200 + i)
+        assert srv.transactions["tx-c"]["outcome"] == "success"
+
+    def test_a_client_terminal_is_not_overridden_by_a_hop_terminal(self, srv):
+        """GET's client-facing verdict is authoritative."""
+        track(srv, "get_request", "tx-d", ts=100)
+        track(srv, "get_terminal", "tx-d", ts=200, terminal_outcome="timeout_exhausted")
+        tx = track(srv, "put_success", "tx-d", ts=300)
+        assert tx["outcome"] == "timeout_exhausted", (
+            "a hop-observed terminal overwrote the client-facing outcome"
+        )
+
+    def test_a_client_terminal_overrides_an_earlier_hop_terminal(self, srv):
+        track(srv, "subscribe_request", "tx-e", ts=100)
+        track(srv, "subscribe_not_found", "tx-e", ts=200)
+        tx = track(srv, "get_terminal", "tx-e", ts=300, terminal_outcome="success")
+        assert tx["outcome"] == "success"

--- a/tests/test_transaction_shape.py
+++ b/tests/test_transaction_shape.py
@@ -226,3 +226,72 @@ class TestContradictoryTerminalsAreResolvedDeterministically:
         track(srv, "subscribe_not_found", "tx-e", ts=200)
         tx = track(srv, "get_terminal", "tx-e", ts=300, terminal_outcome="success")
         assert tx["outcome"] == "success"
+
+
+class TestPrecedenceTableIsTotal:
+    """Two outcomes sharing a rank compare equal, fall through to first-wins,
+    and become arrival-order-dependent again — the property the table exists to
+    remove. So every producible outcome needs a rank, and the ranks must differ.
+    """
+
+    def producible_outcomes(self, srv):
+        from_types = {v[1] for v in srv.TX_TERMINAL_EVENTS.values()}
+        return from_types | srv.CLIENT_TERMINAL_OUTCOMES
+
+    def test_every_producible_outcome_is_ranked(self, srv):
+        unranked = self.producible_outcomes(srv) - set(srv.TX_OUTCOME_PRECEDENCE)
+        assert not unranked, (
+            f"unranked outcomes tie at 0 and resolve by arrival order: {unranked}"
+        )
+
+    def test_ranks_are_distinct(self, srv):
+        ranks = list(srv.TX_OUTCOME_PRECEDENCE.values())
+        assert len(ranks) == len(set(ranks)), "equal ranks reintroduce first-wins"
+
+    @pytest.mark.parametrize("a,b", [
+        ("put_failure", "connect_rejected"),
+        ("connect_rejected", "put_failure"),
+        ("subscribe_timeout", "put_failure"),
+        ("put_failure", "subscribe_timeout"),
+    ])
+    def test_previously_unranked_pairs_resolve_the_same_either_way(self, srv, a, b):
+        """`failure` and `disconnected` used to sit at 0 together."""
+        def settle(order):
+            srv.transactions.clear()
+            srv.transaction_order.clear()
+            for i, et in enumerate(order):
+                srv.track_transaction("tx", et, 100 + i, "peer-a")
+            return srv.transactions["tx"]["outcome"]
+        assert settle([a, b]) == settle([b, a])
+
+
+class TestClientFacingTerminalsWinOnTheirOwnMerit:
+    """Not merely because they happen to rank higher.
+
+    A fixture where the client-facing terminal ALSO wins numerically leaves the
+    authority branch unpinned: deleting it entirely still passes. These pick
+    cases where precedence and client-facing authority actively disagree.
+    """
+
+    def test_a_lower_ranked_client_terminal_still_beats_a_hop_terminal(self, srv):
+        # subscribe_success ranks above not_found, so numeric precedence alone
+        # would keep it; only the client-facing rule overturns that.
+        track(srv, "subscribe_request", "tx-1", ts=100)
+        track(srv, "subscribe_success", "tx-1", ts=200)
+        tx = track(srv, "get_terminal", "tx-1", ts=300, terminal_outcome="not_found")
+        assert tx["outcome"] == "not_found", (
+            "a client-facing terminal must win even when it ranks lower"
+        )
+
+    def test_a_higher_ranked_hop_terminal_cannot_displace_a_client_terminal(self, srv):
+        track(srv, "get_request", "tx-2", ts=100)
+        track(srv, "get_terminal", "tx-2", ts=200, terminal_outcome="not_found")
+        tx = track(srv, "subscribe_success", "tx-2", ts=300)
+        assert tx["outcome"] == "not_found"
+
+    def test_the_two_rules_are_independently_load_bearing(self, srv):
+        """Both directions, so neither branch can be deleted silently."""
+        assert srv.outcome_wins("not_found", "get_terminal",
+                                "success", "subscribe_success") is True
+        assert srv.outcome_wins("success", "subscribe_success",
+                                "not_found", "get_terminal") is False

--- a/ws_server.py
+++ b/ws_server.py
@@ -725,7 +725,6 @@ def get_metrics_timeseries():
         # during the 2026-07-26 growth surge (issue #15).
         get_total = b["gt_ok"] + b["gt_bad"]
         get_sub_total = b["gt_sub_ok"] + b["gt_sub_bad"]
-        sub_total = b["sub_ok"] + b["sub_bad"]
 
         series.append({
             "t": b["ts"],
@@ -733,13 +732,18 @@ def get_metrics_timeseries():
             "get_rate": rate_or_none(b["gt_ok"], get_total),
             "get_sub_rate": rate_or_none(b["gt_sub_ok"], get_sub_total),
             "upd_rate": rate_or_none(b["upd_ok"], upd_total),
-            "sub_rate": rate_or_none(b["sub_ok"], sub_total),
+            # No sub_rate. SUBSCRIBE has no client-facing terminal event, so
+            # subscribe_success/_not_found are minted per hop on the response
+            # path and their ratio weights by hop count — the same defect that
+            # made GET read 0.05% against a real 87% (issue #15). There is no
+            # arithmetic that fixes it, so the counts ship without a rate.
             "put_n": put_total,
             "get_n": get_total,
             "get_sub_n": get_sub_total,
             "upd_n": upd_total,
-            "sub_n": sub_total,
-            # Per-hop routing volume. Deliberately not a success signal.
+            # Per-hop volumes. Deliberately not success signals.
+            "sub_hops_ok": b["sub_ok"],
+            "sub_hops_bad": b["sub_bad"],
             "get_hops_n": b["get_req"] + b["get_nf"],
             "lat_put": p50(b["lat_put"]),
             "lat_get": p50(b["lat_get"]),
@@ -1300,6 +1304,44 @@ TX_TERMINAL_EVENTS = {
 
 TRACKED_TX_OPS = {"put", "get", "update", "broadcast", "connect", "subscribe"}
 
+# Only GET has a client-facing terminal. The core emits GetEvent::ClientTerminal
+# at the client boundary; there is no equivalent variant on SubscribeEvent,
+# PutEvent or UpdateEvent (see event_kind.rs, where ClientTerminal is a GetEvent
+# variant and PutSuccess/SubscribeSuccess/SubscribeNotFound are documented
+# alongside the per-hop GetSuccess/GetNotFound).
+CLIENT_FACING_TERMINALS = {"get_terminal"}
+
+# Hop-observed terminals arrive once per peer on the response path, so a single
+# transaction can produce several — and for SUBSCRIBE they can contradict each
+# other outright (subscribe/op_ctx_task.rs has a path emitting both
+# subscribe_not_found and subscribe_success for one client subscribe).
+# Last-write-wins made the stored outcome depend on collector ingest order, so
+# the same transaction could be recorded either way across restarts. Rank them
+# instead: a success response genuinely traversed the path, whereas a not_found
+# at one hop says nothing about the others.
+TX_OUTCOME_PRECEDENCE = {
+    "success": 4,
+    "not_found": 3,
+    "timeout": 2,
+    "rejected": 1,
+}
+
+
+def outcome_wins(new_outcome, new_event_type, old_outcome, old_event_type):
+    """Should `new_outcome` replace `old_outcome` on the same transaction?
+
+    A client-facing terminal is authoritative and is never overridden by a
+    hop-observed one; otherwise the higher precedence wins, deterministically.
+    """
+    if old_outcome is None:
+        return True
+    if old_event_type in CLIENT_FACING_TERMINALS:
+        return False
+    if new_event_type in CLIENT_FACING_TERMINALS:
+        return True
+    return (TX_OUTCOME_PRECEDENCE.get(new_outcome, 0)
+            > TX_OUTCOME_PRECEDENCE.get(old_outcome, 0))
+
 
 def classify_tx_event(event_type):
     """Map an event type to (op_type, role) where role is 'start', 'terminal'
@@ -1373,6 +1415,9 @@ def track_transaction(tx_id, event_type, timestamp, peer_id, contract_key=None,
             # nothing about how it ended.
             "tx_shape": "open" if is_start else "partial",
             "outcome": None,
+            # Which event set `outcome`, so a hop-observed terminal cannot
+            # overwrite a client-facing one.
+            "outcome_src": None,
         }
         transaction_order.append(tx_id)
         prune_old_transactions()
@@ -1397,6 +1442,10 @@ def track_transaction(tx_id, event_type, timestamp, peer_id, contract_key=None,
     if timestamp < tx["start_ns"]:
         tx["start_ns"] = timestamp
 
+    # A start only promotes an unclassified transaction. get_request is per-HOP,
+    # so a relay's request can legitimately arrive after the originator's
+    # terminal; without this guard that late event would demote a settled
+    # transaction back to 'open' while leaving its outcome in place.
     if is_start and tx["tx_shape"] == "partial":
         tx["tx_shape"] = "open"
 
@@ -1404,7 +1453,9 @@ def track_transaction(tx_id, event_type, timestamp, peer_id, contract_key=None,
     if is_end:
         tx["end_ns"] = timestamp
         tx["tx_shape"] = "settled"
-        tx["outcome"] = outcome
+        if outcome_wins(outcome, event_type, tx["outcome"], tx["outcome_src"]):
+            tx["outcome"] = outcome
+            tx["outcome_src"] = event_type
     elif timestamp > (tx["end_ns"] or 0):
         tx["end_ns"] = timestamp
 
@@ -2173,9 +2224,6 @@ def get_operation_stats():
     sub_op = get["term_sub_op"]
     direct_total = sum(direct.values())
     sub_op_total = sum(sub_op.values())
-    sub_total = (subscribe["successes"] + subscribe["not_found"]
-                 + subscribe["timeouts"])
-
     return {
         "put": {
             "total": put["requests"],
@@ -2201,12 +2249,15 @@ def get_operation_stats():
             "broadcasts": update["broadcasts"],
             "latency": calc_percentiles(update["latencies"]),
         },
+        # SUBSCRIBE counters are per-HOP observations, named so they cannot be
+        # read as an operation outcome. No success_rate: see the note in
+        # get_metrics_timeseries — SUBSCRIBE has no client-facing terminal
+        # event, so no honest rate can be derived from these.
         "subscribe": {
-            "total": sub_total,
-            "requests": subscribe["requests"],
-            "success_rate": calc_rate(subscribe["successes"], sub_total) if sub_total else None,
-            "not_found": subscribe["not_found"],
-            "timeouts": subscribe["timeouts"],
+            "hop_requests": subscribe["requests"],
+            "hop_successes": subscribe["successes"],
+            "hop_not_found": subscribe["not_found"],
+            "hop_timeouts": subscribe["timeouts"],
         },
     }
 

--- a/ws_server.py
+++ b/ws_server.py
@@ -1319,12 +1319,23 @@ CLIENT_FACING_TERMINALS = {"get_terminal"}
 # the same transaction could be recorded either way across restarts. Rank them
 # instead: a success response genuinely traversed the path, whereas a not_found
 # at one hop says nothing about the others.
+# Every rank is distinct and every producible outcome appears: two outcomes
+# sharing a rank would compare equal, fall through to first-wins, and be
+# arrival-order-dependent again — the exact property this table exists to
+# remove. tx_outcome_precedence_is_total() pins that.
 TX_OUTCOME_PRECEDENCE = {
-    "success": 4,
-    "not_found": 3,
-    "timeout": 2,
-    "rejected": 1,
+    "success": 7,
+    "not_found": 6,
+    "timeout_exhausted": 5,
+    "timeout": 4,
+    "rejected": 3,
+    "failure": 2,
+    "disconnected": 1,
 }
+
+# Outcomes get_terminal can carry, which do not appear in TX_TERMINAL_EVENTS
+# because they arrive in the event body rather than being implied by the type.
+CLIENT_TERMINAL_OUTCOMES = {"success", "not_found", "timeout_exhausted"}
 
 
 def outcome_wins(new_outcome, new_event_type, old_outcome, old_event_type):


### PR DESCRIPTION
Follow-up to #16, addressing findings from four independent review lenses. #16 is merged but **not deployed** — the dashboard checkout is still at `6a54d28` — so none of what this fixes has reached a user.

## Problem

Four things, in descending order of consequence.

**1. The migration was one-way, and rollback was worse than it looked.** #16 renamed `status` → `tx_shape` and rewrote legacy values in place. `flush()` batches events, transactions, tx_events, flows and get_terminals into a single transaction, and `_try_flush` sets `_enabled = False` permanently on error — so rolling back to pre-#16 code would hit a missing column, abort the whole batch, and silently stop **all** dashboard ingest while the process kept running and looked healthy.

**2. #16 fixed the per-hop trap for GET and re-armed it for SUBSCRIBE.** The core emits `GetEvent::ClientTerminal` at the client boundary, but there is no equivalent on `SubscribeEvent` — `subscribe_success` is minted at every peer on the response path (`register.rs`, on `SubscribeMsg::Response`, whose own comment notes hop_count is "preserved by relays bubbling up"). #16 nonetheless added a `sub_rate` over those counters, under a schema comment vouching for it as "the MEASURED result". Measured events per distinct `tx_id`:

| event | per-tx |
|---|---|
| `get_not_found` | 17.55 |
| `get_request` | 8.95 |
| `subscribe_not_found` | 7.42 |
| `subscribe_success` | 1.19 |
| **`get_terminal`** | **1.00** |

So the added rate read **84.0%** where the per-transaction figure is **97.0%** — biased the same direction as the GET defect it was fixing. `get_terminal` at exactly 1.00 per transaction is the control that shows why it is the right source for GET.

**3. Contradictory terminals were resolved by ingest order.** `subscribe/op_ctx_task.rs` has a path emitting both `subscribe_not_found` and `subscribe_success` for one client subscribe. `track_transaction` was last-write-wins, so the stored outcome depended on which the collector happened to ingest last, and could differ across restarts for the same transaction.

**4. The documented recovery path produced a blank GET chart.** `backfill_db.py` kept a hand-transcribed copy of the schema which silently omitted `get_terminals` — the table `precompute_metrics_from_db()` sources GET rates from. An operator following the documented recovery got PUT and UPDATE restored and both GET lines empty: the exact metric this work exists to fix.

## Approach

**Additive-only migration.** `status` stays, untouched; `tx_shape TEXT DEFAULT 'partial'` and `outcome TEXT` are appended beside it. No rename, no `UPDATE`. Measured on 2,931,393 rows: **0.032s** (against 7.1s), because `ADD COLUMN` with a constant DEFAULT is metadata-only. Nothing is lost — legacy rows keep their real value in `status` and report `tx_shape='partial'`, which honestly means "not classified". It also stops promoting per-hop GET verdicts into `outcome`: a legacy `status='success'` on a GET came from `get_success`.

Read-time derivation was considered and rejected: it would make a legacy row answer `partial` to direct SQL and `settled` to the dashboard API, and ad-hoc SQL against this database is precisely how the original misdiagnosis happened.

**No `user_version` gate.** The previous version needed one to stop an expensive rewrite re-running every restart. With nothing expensive left, `ADD COLUMN`'s own if-absent check is cheaper and more honest, and a version counter no migration consults is a claim about ordering we would not be keeping. Argued here rather than dropped silently, as asked.

**No SUBSCRIBE success rate.** Not corrected — removed. There is no telemetry it could be computed from. Counts ship as `hop_requests` / `hop_successes` / `hop_not_found` / `hop_timeouts`, named so they cannot be read as outcomes, and `sub_hops_ok` / `sub_hops_bad` in the series.

**Precedence, not last-write-wins.** `TX_OUTCOME_PRECEDENCE` ranks contradictory terminals deterministically, and a client-facing terminal is never overridden by a hop-observed one. The schema comment now states plainly that `outcome` is client-facing for GET and hop-observed otherwise, rather than vouching for all of it.

**Shared definitions instead of copies.** `backfill_db.py` imports the server's `SCHEMA_TABLES`, classification tables and precedence helper. It had drifted twice — keying subscribes off `subscribed` (never emitted) and recording `get_not_found` as `"success"` — so this makes that class of bug unrepresentable rather than merely tested for.

**No index on `get_terminals`, decided by measurement.** #16 added one and nothing creates indexes at startup, so it would only have existed if an operator ran `create_indexes.py`. Measuring it settled the question the other way: on a full 24h window (250k rows) the startup aggregate takes **382ms scanning and 799ms with the index**, because it groups the entire retention window and a table scan beats index-ordered lookups. The only query it helps is prune's probe (65ms → 22ms, against a 5s budget). The index is removed rather than wired up, so correctness no longer depends on an operator step at all.

Plus: the `unsubscribed` client/server drift (#16 fixed only the Python side); `create_indexes.py` aborting on a database predating `get_terminals`; removal of a zero-caller `ensure_indexes()` that read as "indexes are created for you" when calling it would have locked ingest for 30+ minutes; and an `AVG` documented as a median.

## Testing

122 tests, up from 92. **Nine mutations, each executed and each now caught** — including the two that survived the previous suite:

| mutation | before | now |
|---|---|---|
| `ok = outcome == "success"` → `ok = True` in precompute | 92 passed | 3 fail |
| drop the `tx_shape == "partial"` late-start guard | 92 passed | 5 fail |
| last-write-wins instead of precedence | — | 2 fail |
| re-add `sub_rate` | — | 2 fail |
| re-introduce the `unsubscribed` drift | — | 1 fail |
| migration drops `status` | — | 6 fail |
| backfill stops writing `get_terminals` | — | 1 fail |
| backfill re-transcribes the schema | — | 1 fail |
| re-add the `get_terminals` index | — | 1 fail |

The precompute gap mattered most: that path rebuilds what the dashboard shows most of the time, and every previous test fed it only `outcome='success'` at `is_sub_op=0`. It now gets mixed outcomes at both `is_sub_op` values, plus a test asserting the rebuild matches the live path.

The precedence rule is tested in **both** arrival orders, so it cannot be fixture-shaped: `not_found` then `success` and `success` then `not_found` both settle on `success`, a 4-hop repeat is stable, and a client-facing terminal survives a later hop-observed one in both directions.

The agreement test was widened to compare `op` as well as `role` — asserting only `role is None` for anything outside the two tables is exactly why it was blind to the `unsubscribed` drift.

Migration verified at production row count on a local disposable replica, including that a pre-#16 `INSERT` naming `status` still succeeds afterwards. No SQL was run against the production database.

## What has no UI consumer

Worth stating rather than leaving to be discovered. `op_stats` reaches no pixel: `updateOpStats()` is a no-op stub at `js/websocket.js` and the DOM ids it would write do not exist in `index.html`. Three reviewers found this independently. So the SUBSCRIBE half of #16 was never visible — which is the only reason the bad `sub_rate` never misled anyone. `transactions.tx_shape`/`outcome` are likewise sent to the browser and never rendered. The **Performance chart is the live surface**: `get_rate` and `get_sub_rate` are plotted and are correct.

## Not fixed here, flagged with evidence

`put_rate` and `upd_rate` are plotted on that chart and are pre-existing, built from the same family of counters. `update_request` (99,594) against `update_success` (2,290) puts `upd_rate` around 2.3%, which has the same smell. I have not characterised them properly — current PUT/UPDATE volume is too low to measure a per-transaction ratio the way I could for GET and SUBSCRIBE — and silently changing two existing chart lines is not something to fold into this PR. Recommended as the next investigation.

Filed as **#18** with the counter shapes, the measured numbers, and — most importantly — the exact query that would settle it and why it cannot be run yet. Two of the three defects there (a denominator that silently becomes the numerator when no request events are seen, and an unclamped percentage that can plot above 100%) are worth fixing regardless of how the events turn out to be emitted.

Also unchanged from #16: the orphaned root `app.js` (161 KB) still contains the pre-modularization version of this bug. Nothing loads it.

Refs #15

[AI-assisted - Claude]
