### PR TITLE
fix: report GET success over routed GETs, not local cache hits

### DIFF
--- a/css/metrics.css
+++ b/css/metrics.css
@@ -119,12 +119,26 @@
             min-width: 168px;
         }
 
+        .get-health-aside-head {
+            font-family: var(--font-mono);
+            font-size: 0.64em;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            color: var(--text-muted);
+            margin-bottom: 2px;
+        }
+
         .get-health-aside-row {
             display: flex;
             justify-content: space-between;
             gap: 12px;
             font-family: var(--font-mono);
             font-size: 0.72em;
+        }
+
+        .get-health-aside-row em {
+            font-style: normal;
+            opacity: 0.65;
         }
 
         .get-health-aside-row .label { color: var(--text-muted); }

--- a/css/metrics.css
+++ b/css/metrics.css
@@ -42,11 +42,116 @@
             min-height: 300px;
             position: relative;
             padding: 4px 0;
+            display: flex;
+            flex-direction: column;
+        }
+
+        .metrics-canvas-wrap {
+            flex: 1;
+            min-height: 220px;
+            position: relative;
         }
 
         .metrics-chart-container canvas {
             width: 100% !important;
             height: 100% !important;
+        }
+
+        /* ── GET health summary (routed vs local-hit split) ── */
+        .get-health {
+            display: flex;
+            align-items: stretch;
+            gap: 14px;
+            padding: 10px 12px;
+            margin-bottom: 8px;
+            background: var(--bg-panel);
+            border: 1px solid var(--border-color);
+            border-radius: 10px;
+        }
+
+        .get-health-main {
+            flex: 1;
+            min-width: 0;
+        }
+
+        .get-health-label {
+            font-family: var(--font-mono);
+            font-size: 0.72em;
+            font-weight: 600;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            color: var(--text-secondary);
+        }
+
+        .get-health-window {
+            font-weight: 400;
+            text-transform: none;
+            letter-spacing: 0;
+            color: var(--text-muted);
+            margin-left: 6px;
+        }
+
+        .get-health-rate {
+            font-family: var(--font-mono);
+            font-size: 1.9em;
+            font-weight: 600;
+            line-height: 1.15;
+            color: var(--text-primary);
+        }
+
+        .get-health-rate.good { color: var(--color-get); }
+        .get-health-rate.warn { color: var(--color-put); }
+        .get-health-rate.bad  { color: var(--color-error); }
+
+        .get-health-sub {
+            font-family: var(--font-mono);
+            font-size: 0.72em;
+            color: var(--text-muted);
+        }
+
+        .get-health-aside {
+            display: flex;
+            flex-direction: column;
+            justify-content: center;
+            gap: 4px;
+            padding-left: 14px;
+            border-left: 1px solid var(--border-color);
+            min-width: 168px;
+        }
+
+        .get-health-aside-row {
+            display: flex;
+            justify-content: space-between;
+            gap: 12px;
+            font-family: var(--font-mono);
+            font-size: 0.72em;
+        }
+
+        .get-health-aside-row .label { color: var(--text-muted); }
+        .get-health-aside-row .val { color: var(--text-secondary); }
+        .get-health-aside-row.warnrow .val { color: var(--color-error); }
+
+        .get-health-note {
+            font-size: 0.7em;
+            line-height: 1.5;
+            color: var(--text-muted);
+            padding: 8px 2px 2px 2px;
+        }
+
+        .get-health-note code {
+            font-family: var(--font-mono);
+            font-size: 0.95em;
+            color: var(--text-secondary);
+        }
+
+        @media (max-width: 768px) {
+            .get-health { flex-direction: column; gap: 8px; }
+            .get-health-aside {
+                padding-left: 0;
+                border-left: none;
+                border-top: 1px solid var(--border-color);
+                padding-top: 8px;
+            }
         }
 
         /* Ensure the panel stretches for the chart */

--- a/js/metrics.js
+++ b/js/metrics.js
@@ -57,6 +57,114 @@ function ema(data, alpha = 0.35) {
     return result;
 }
 
+const NUM = new Intl.NumberFormat();
+
+/**
+ * Sum the raw GET counts over the last `hours` of the series.
+ *
+ * The summary above the chart answers "is the network serving requests right
+ * now", so it aggregates recent raw counts rather than averaging the per-bucket
+ * rates — averaging rates would weight a quiet bucket the same as a busy one.
+ */
+function recentGetTotals(series, hours = 24) {
+    const cutoff = series.length
+        ? series[series.length - 1].t - hours * 3600 * 1e9
+        : 0;
+    const t = {
+        routed: 0, routedOk: 0, routedNf: 0, routedTimeout: 0,
+        local: 0, unknown: 0, subOp: 0,
+    };
+    for (const p of series) {
+        if (p.t < cutoff) continue;
+        const routedN = p.get_routed_n || 0;
+        t.routed += routedN;
+        // get_routed_rate is null in a bucket below the minimum sample count,
+        // but its raw counts are still real and belong in the total.
+        if (p.get_routed_rate != null) {
+            t.routedOk += Math.round(routedN * p.get_routed_rate / 100);
+        }
+        t.routedNf += p.get_routed_nf_n || 0;
+        t.routedTimeout += p.get_routed_timeout_n || 0;
+        t.local += p.get_local_n || 0;
+        t.unknown += p.get_unknown_n || 0;
+        t.subOp += p.get_sub_n || 0;
+    }
+    return t;
+}
+
+function pct(n, d) {
+    return d > 0 ? Math.round(n / d * 1000) / 10 : null;
+}
+
+function rateClass(rate) {
+    if (rate == null) return '';
+    if (rate >= 90) return 'good';
+    if (rate >= 60) return 'warn';
+    return 'bad';
+}
+
+/**
+ * The headline: network-routed GET success, with the failure split beside it.
+ *
+ * Routed and local-store GETs are reported apart on purpose. A local hit
+ * (attempts === 0 on the core's ClientTerminal event) never leaves the machine
+ * and so cannot fail; it was ~95% of client GETs, which held the old blended
+ * "GET success" line near 95% while routed success was 8.5%. A number that
+ * stays high whether or not the network works cannot answer the only question
+ * this panel is for.
+ */
+function renderGetSummary(series) {
+    const t = recentGetTotals(series);
+    const routedRate = pct(t.routedOk, t.routed);
+    const el = document.createElement('div');
+    el.className = 'get-health';
+
+    const nfShare = pct(t.routedNf, t.routed);
+    const toShare = pct(t.routedTimeout, t.routed);
+    const breakdown = t.routed
+        ? `not found ${nfShare}% &middot; timed out ${toShare}%`
+        : 'no routed GETs in this window';
+
+    el.innerHTML = `
+        <div class="get-health-main">
+            <div class="get-health-label">Network GET success <span class="get-health-window">last 24h</span></div>
+            <div class="get-health-rate ${rateClass(routedRate)}">${
+                routedRate == null ? '&mdash;' : routedRate + '%'
+            }</div>
+            <div class="get-health-sub">${NUM.format(t.routed)} routed &middot; ${breakdown}</div>
+        </div>
+        <div class="get-health-aside">
+            <div class="get-health-aside-row">
+                <span class="label">Local cache hits</span>
+                <span class="val">${NUM.format(t.local)}</span>
+            </div>
+            <div class="get-health-aside-row">
+                <span class="label">Sub-op GETs</span>
+                <span class="val">${NUM.format(t.subOp)}</span>
+            </div>
+            ${t.unknown ? `<div class="get-health-aside-row warnrow">
+                <span class="label">Unclassified</span>
+                <span class="val">${NUM.format(t.unknown)}</span>
+            </div>` : ''}
+        </div>`;
+    return el;
+}
+
+function getHealthFootnote() {
+    const el = document.createElement('div');
+    el.className = 'get-health-note';
+    el.innerHTML =
+        'GET success counts only <strong>routed</strong> GETs &mdash; those that actually ' +
+        'sent a request to another peer (<code>attempts &ge; 1</code>). ' +
+        'Local cache hits (<code>attempts = 0</code>) are excluded: they never reach the ' +
+        'network, always succeed, and were ~95% of client GETs, so including them ' +
+        'produced a ~95% reading while routed GETs were at 8.5%. ' +
+        'Sub-op GETs are internal repair/renewal traffic, not client requests. ' +
+        'PUT and UPDATE are per-hop counts, not client-visible outcomes &mdash; ' +
+        'treat them as volume, not success.';
+    return el;
+}
+
 export function initMetricsChart(container) {
     if (chart) {
         chart.destroy();
@@ -64,9 +172,6 @@ export function initMetricsChart(container) {
     }
 
     container.innerHTML = '';
-    chartCanvas = document.createElement('canvas');
-    chartCanvas.id = 'metrics-canvas';
-    container.appendChild(chartCanvas);
 
     const data = state.metricsTimeseries;
     if (!data || !data.series || data.series.length === 0) {
@@ -74,16 +179,29 @@ export function initMetricsChart(container) {
         return;
     }
 
+    container.appendChild(renderGetSummary(data.series));
+
+    const canvasWrap = document.createElement('div');
+    canvasWrap.className = 'metrics-canvas-wrap';
+    chartCanvas = document.createElement('canvas');
+    chartCanvas.id = 'metrics-canvas';
+    canvasWrap.appendChild(chartCanvas);
+    container.appendChild(canvasWrap);
+    container.appendChild(getHealthFootnote());
+
     const series = data.series;
     const versions = data.versions || [];
 
     const labels = series.map(p => new Date(p.t / 1_000_000));
 
     // Raw rates for tooltips.
-    // get_rate is the CLIENT-FACING direct GET success rate, measured from
-    // get_terminal. It used to be derived from the per-hop get_success /
-    // get_not_found counts, which understated it by ~600x (issue #15).
-    const rawGet = series.map(p => p.get_rate);
+    // get_routed_rate is the CLIENT-FACING success rate of GETs that actually
+    // routed, measured from get_terminal. Two defects had to be removed to get
+    // here: deriving it from the per-hop get_success / get_not_found counts
+    // understated it by ~600x (issue #15), and blending in attempts===0 local
+    // store hits — which cannot fail and were 95% of the denominator — held it
+    // near 95% while routed GETs were succeeding 8.5% of the time.
+    const rawGet = series.map(p => p.get_routed_rate);
     const rawGetSub = series.map(p => p.get_sub_rate);
     const rawPut = series.map(p => p.put_rate);
     const rawUpd = series.map(p => p.upd_rate);
@@ -104,7 +222,9 @@ export function initMetricsChart(container) {
             labels: labels,
             datasets: [
                 {
-                    label: 'GET',
+                    // Named for its population. A bare "GET" is what let a
+                    // cache-hit-dominated rate pass as network health.
+                    label: 'GET (routed)',
                     data: smoothGet,
                     borderColor: C.get,
                     backgroundColor: C.get + '18',
@@ -216,12 +336,25 @@ export function initMetricsChart(container) {
                             // Show raw (unsmoothed) value + sample count
                             const lbl = item.dataset.label;
                             let raw, count;
-                            if (lbl === 'GET') { raw = rawGet[idx]; count = s.get_n; }
+                            if (lbl === 'GET (routed)') { raw = rawGet[idx]; count = s.get_routed_n; }
                             else if (lbl === 'GET (sub-op)') { raw = rawGetSub[idx]; count = s.get_sub_n; }
                             else if (lbl === 'PUT') { raw = rawPut[idx]; count = s.put_n; }
                             else if (lbl === 'UPDATE') { raw = rawUpd[idx]; count = s.upd_n; }
                             if (raw == null) return ` ${lbl}: insufficient data`;
-                            return ` ${lbl}: ${raw}% (${count} ops)`;
+                            const line = ` ${lbl}: ${raw}% (${count} ops)`;
+                            if (lbl !== 'GET (routed)') return line;
+                            // Spell out WHY routed GETs failed and how many
+                            // GETs never routed at all, so the small routed
+                            // denominator reads as a split rather than a gap.
+                            const extra = [
+                                ` failed: ${s.get_routed_nf_n || 0} not found, ` +
+                                `${s.get_routed_timeout_n || 0} timed out`,
+                                ` ${s.get_local_n || 0} local cache hits (not routed)`,
+                            ];
+                            if (s.get_unknown_n) {
+                                extra.push(` ${s.get_unknown_n} unclassified — rate is undercounting`);
+                            }
+                            return [line, ...extra];
                         }
                     }
                 },
@@ -285,17 +418,23 @@ export function updateMetricsChart() {
     const series = data.series;
     const labels = series.map(p => new Date(p.t / 1_000_000));
 
-    const rawGet = series.map(p => p.get_rate);
+    const rawGet = series.map(p => p.get_routed_rate);
     const rawGetSub = series.map(p => p.get_sub_rate);
     const rawPut = series.map(p => p.put_rate);
     const rawUpd = series.map(p => p.upd_rate);
+
+    // The summary above the chart is a 24h aggregate, so it has to be rebuilt
+    // on refresh too — a stale headline is the failure mode this panel is
+    // supposed to have stopped having.
+    const summary = document.querySelector('.get-health');
+    if (summary) summary.replaceWith(renderGetSummary(series));
 
     chart.data.labels = labels;
     // Match datasets by label rather than position: this list has been indexed
     // positionally before, so inserting a series silently fed one line another
     // line's data.
     const byLabel = {
-        'GET': rawGet,
+        'GET (routed)': rawGet,
         'GET (sub-op)': rawGetSub,
         'PUT': rawPut,
         'UPDATE': rawUpd,

--- a/js/metrics.js
+++ b/js/metrics.js
@@ -123,27 +123,34 @@ function renderGetSummary(series) {
     const toShare = pct(t.routedTimeout, t.routed);
     const breakdown = t.routed
         ? `not found ${nfShare}% &middot; timed out ${toShare}%`
-        : 'no routed GETs in this window';
+        : 'nothing routed in this window';
 
+    // The denominator is spelled out in the label and restated under the
+    // number. The old metric was arithmetically correct and still misleading,
+    // because nothing on screen said what it was dividing by; a reader had no
+    // way to notice that most of the denominator could not fail. Naming the
+    // population, its size, and what was excluded (with the reason) is what
+    // makes that class of error hard to repeat.
     el.innerHTML = `
         <div class="get-health-main">
-            <div class="get-health-label">Network GET success <span class="get-health-window">last 24h</span></div>
+            <div class="get-health-label">GET success &mdash; network-routed only<span class="get-health-window">last 24h</span></div>
             <div class="get-health-rate ${rateClass(routedRate)}">${
                 routedRate == null ? '&mdash;' : routedRate + '%'
             }</div>
-            <div class="get-health-sub">${NUM.format(t.routed)} routed &middot; ${breakdown}</div>
+            <div class="get-health-sub">of ${NUM.format(t.routed)} GETs that contacted a peer &middot; ${breakdown}</div>
         </div>
         <div class="get-health-aside">
+            <div class="get-health-aside-head">Excluded from the rate</div>
             <div class="get-health-aside-row">
-                <span class="label">Local cache hits</span>
+                <span class="label">Local cache hits <em>cannot fail</em></span>
                 <span class="val">${NUM.format(t.local)}</span>
             </div>
             <div class="get-health-aside-row">
-                <span class="label">Sub-op GETs</span>
+                <span class="label">Sub-op GETs <em>internal</em></span>
                 <span class="val">${NUM.format(t.subOp)}</span>
             </div>
             ${t.unknown ? `<div class="get-health-aside-row warnrow">
-                <span class="label">Unclassified</span>
+                <span class="label">Unclassified <em>rate undercounts</em></span>
                 <span class="val">${NUM.format(t.unknown)}</span>
             </div>` : ''}
         </div>`;

--- a/js/metrics.js
+++ b/js/metrics.js
@@ -76,13 +76,13 @@ function recentGetTotals(series, hours = 24) {
     };
     for (const p of series) {
         if (p.t < cutoff) continue;
-        const routedN = p.get_routed_n || 0;
-        t.routed += routedN;
-        // get_routed_rate is null in a bucket below the minimum sample count,
-        // but its raw counts are still real and belong in the total.
-        if (p.get_routed_rate != null) {
-            t.routedOk += Math.round(routedN * p.get_routed_rate / 100);
-        }
+        t.routed += p.get_routed_n || 0;
+        // Sum the server's exact success count. Do NOT reconstruct it from
+        // get_routed_rate: that is null in any bucket below the minimum sample
+        // count, so the successes vanished while the volume stayed, understating
+        // the headline (a true 100% reported as 87%) — worst exactly during the
+        // low-traffic periods this metric exists to catch.
+        t.routedOk += p.get_routed_ok_n || 0;
         t.routedNf += p.get_routed_nf_n || 0;
         t.routedTimeout += p.get_routed_timeout_n || 0;
         t.local += p.get_local_n || 0;

--- a/telemetry_db.py
+++ b/telemetry_db.py
@@ -642,6 +642,33 @@ class TelemetryDB:
     # first peer answered; `0` is the convention for a LOCAL-cache hit that never
     # routed to the network ... letting analysts split 'all client GET successes'
     # (attempts >= 0) from 'network GET findability' (attempts >= 1)".
+    #
+    # WHY NOT hop_count. freenet-core itself stopped splitting on `attempts` in
+    # #4852 P2: `summarize_client_get_outcomes` (core `tracing.rs`) now splits on
+    # `hop_count >= 1`, because a loopback `LocalCompletion` bumps `requests_sent`
+    # (so attempts >= 1) with no network round-trip and would be over-counted as a
+    # network success. The doc comment quoted above predates that and was never
+    # updated, so it still recommends the split core abandoned. Both facts are
+    # real. We still use `attempts` here, for two measured reasons:
+    #
+    #   1. hop_count is not populated in this telemetry. Over ~24h of direct
+    #      GETs: 224,736 NULL, 242 zero, 2 non-zero. Splitting on `hop_count >= 1`
+    #      would report 2 network GETs out of 225k. It is unusable as a splitter,
+    #      whatever its semantics.
+    #   2. The loopback contamination that motivated core's switch is absent from
+    #      this data, and latency proves it. A LocalCompletion has no network
+    #      round-trip, so it must be ~0 ms. The populations separate with an EMPTY
+    #      band between them: attempts=0 tops out at 15 ms (213,461 of 213,744
+    #      under 1 ms), and attempts>=1 successes start at 60 ms — zero rows below
+    #      50 ms, zero rows in between. If loopbacks were landing in attempts>=1
+    #      they would show up as ~0 ms successes there. There are none.
+    #
+    # That same separation also rules out a version-skew reading: a release that
+    # emitted attempts=0 for a GET that really routed would appear as a slow
+    # attempts=0 row, and there are none.
+    #
+    # If hop_count ever starts being populated, prefer it — it is the more direct
+    # signal and core's reasoning is sound. Re-check the latency separation first.
     ROUTE_CLASS_SQL = (
         "CASE WHEN attempts IS NULL THEN 'unknown' "
         "WHEN attempts = 0 THEN 'local' ELSE 'network' END"

--- a/telemetry_db.py
+++ b/telemetry_db.py
@@ -106,6 +106,17 @@ CREATE TABLE IF NOT EXISTS transactions (
 -- tracks route length, not user-visible success. Kept as its own small table
 -- (~200k rows/day) so GET health can be aggregated without either scanning the
 -- multi-hundred-GB events table or adding an event_type index to it.
+--
+-- `attempts` is load-bearing and must be split on before any rate is computed:
+--   attempts = 0   -- LOCAL store hit. The GET never left the machine, so it
+--                     cannot fail. 100.00% success over 213,787 samples in the
+--                     24h to 2026-08-08, and 0 ms at p50/p90/p99.
+--   attempts >= 1  -- NETWORK-ROUTED. This is the only population that measures
+--                     whether the network can serve a request.
+-- Local hits are ~95% of direct GETs, so a rate over the union is ~95% no
+-- matter how badly the network is doing — it read 95.4% on 2026-08-08 while
+-- routed GET success was 8.5% (not_found 74.2%, timeout_exhausted 17.3%).
+-- Never aggregate across the two. See TelemetryDB.route_class.
 CREATE TABLE IF NOT EXISTS get_terminals (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     timestamp_ns INTEGER NOT NULL,
@@ -621,13 +632,47 @@ class TelemetryDB:
             })
         return result
 
+    # `attempts` classification, shared by the SQL below and by ws_server's live
+    # path so a restart cannot reclassify history. See ROUTE_CLASS_SQL.
+    ROUTE_LOCAL = "local"      # attempts == 0: answered from the local store
+    ROUTE_NETWORK = "network"  # attempts >= 1: at least one GET was sent
+    ROUTE_UNKNOWN = "unknown"  # attempts absent: which one is unmeasured
+
+    # attempts is the core's own split (GetEvent::ClientTerminal): "`1` means the
+    # first peer answered; `0` is the convention for a LOCAL-cache hit that never
+    # routed to the network ... letting analysts split 'all client GET successes'
+    # (attempts >= 0) from 'network GET findability' (attempts >= 1)".
+    ROUTE_CLASS_SQL = (
+        "CASE WHEN attempts IS NULL THEN 'unknown' "
+        "WHEN attempts = 0 THEN 'local' ELSE 'network' END"
+    )
+
+    @staticmethod
+    def route_class(attempts):
+        """Classify one terminal's `attempts` the way ROUTE_CLASS_SQL does.
+
+        The live counter path and the post-restart rebuild MUST agree, so both
+        go through this rather than each writing its own comparison.
+        """
+        if attempts is None:
+            return TelemetryDB.ROUTE_UNKNOWN
+        return TelemetryDB.ROUTE_LOCAL if attempts == 0 else TelemetryDB.ROUTE_NETWORK
+
     def get_terminal_buckets(self, since_ns, bucket_ns, until_ns=None):
         """Aggregate client-facing GET outcomes into time buckets.
 
-        Returns rows of (bucket_ts, outcome, is_sub_op, count, mean elapsed_ms).
-        The mean is not currently consumed — get_terminal reports elapsed_ms=0
-        on ~99.5% of successful direct GETs, so latency comes from the
-        get_request -> get_success delta instead.
+        Returns rows of
+        (bucket_ts, outcome, is_sub_op, route_class, count, mean elapsed_ms).
+
+        `route_class` splits local-store hits from network-routed GETs and is
+        NOT optional detail: a local hit never leaves the machine and therefore
+        cannot fail, so blending the two produces a success rate whose
+        denominator is ~95% cases with no failure mode. Through 2026-08-08 that
+        blend read ~95% while network-routed GET success was 8.5%.
+
+        The mean elapsed_ms is not currently consumed — get_terminal reports
+        elapsed_ms=0 on ~99.5% of successful direct GETs, so latency comes from
+        the get_request -> get_success delta instead.
         Reads the small get_terminals projection rather than the events table,
         which has no event_type index and is hundreds of GB.
 
@@ -635,19 +680,18 @@ class TelemetryDB:
         (e.g. sim/CI telemetry hitting this same prod endpoint) — one such
         row is enough to stretch the metrics chart's time axis across months.
         """
+        select = (
+            f"SELECT (timestamp_ns / {int(bucket_ns)}) * {int(bucket_ns)} AS bucket, "
+            f"outcome, is_sub_op, {self.ROUTE_CLASS_SQL} AS route_class, "
+            "COUNT(*), AVG(elapsed_ms) FROM get_terminals "
+        )
+        group = " GROUP BY bucket, outcome, is_sub_op, route_class ORDER BY bucket"
         if until_ns is None:
             return self.conn.execute(
-                f"SELECT (timestamp_ns / {int(bucket_ns)}) * {int(bucket_ns)} AS bucket, "
-                "outcome, is_sub_op, COUNT(*), AVG(elapsed_ms) "
-                "FROM get_terminals WHERE timestamp_ns > ? "
-                "GROUP BY bucket, outcome, is_sub_op ORDER BY bucket",
-                (since_ns,),
+                select + "WHERE timestamp_ns > ?" + group, (since_ns,),
             ).fetchall()
         return self.conn.execute(
-            f"SELECT (timestamp_ns / {int(bucket_ns)}) * {int(bucket_ns)} AS bucket, "
-            "outcome, is_sub_op, COUNT(*), AVG(elapsed_ms) "
-            "FROM get_terminals WHERE timestamp_ns > ? AND timestamp_ns <= ? "
-            "GROUP BY bucket, outcome, is_sub_op ORDER BY bucket",
+            select + "WHERE timestamp_ns > ? AND timestamp_ns <= ?" + group,
             (since_ns, until_ns),
         ).fetchall()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,8 +28,14 @@ def srv(tmp_path):
     ws_server.op_stats["put"].update(requests=0, successes=0, latencies=[])
     ws_server.op_stats["get"].update(
         hop_requests=0, hop_not_found=0,
-        term_direct={"success": 0, "not_found": 0, "other": 0},
-        term_sub_op={"success": 0, "not_found": 0, "other": 0},
+        term_direct_net={"success": 0, "not_found": 0,
+                         "timeout_exhausted": 0, "other": 0},
+        term_direct_loc={"success": 0, "not_found": 0,
+                         "timeout_exhausted": 0, "other": 0},
+        term_direct_unk={"success": 0, "not_found": 0,
+                         "timeout_exhausted": 0, "other": 0},
+        term_sub_op={"success": 0, "not_found": 0,
+                     "timeout_exhausted": 0, "other": 0},
         latencies=[],
     )
     ws_server.op_stats["update"].update(requests=0, successes=0, broadcasts=0, latencies=[])

--- a/tests/test_db_schema.py
+++ b/tests/test_db_schema.py
@@ -155,10 +155,58 @@ class TestGetTerminalsTable:
             db.flush()
 
             rows = db.get_terminal_buckets(base - bucket, bucket)
-            agg = {(r[1], r[2]): r[3] for r in rows}
-            assert agg[("success", 0)] == 7
-            assert agg[("timeout_exhausted", 1)] == 3
+            # (outcome, is_sub_op, route_class) -> count. route_class is not
+            # optional detail: attempts=0 above means those 7 successes were
+            # local-store hits that never routed.
+            agg = {(r[1], r[2], r[3]): r[4] for r in rows}
+            assert agg[("success", 0, "local")] == 7
+            assert agg[("timeout_exhausted", 1, "network")] == 3
             assert len({r[0] for r in rows}) == 1, "all samples share one bucket"
+        finally:
+            db.close()
+
+    def test_attempts_is_classified_local_network_or_unknown(self, tmp_path):
+        """The split the GET success rate depends on, at its source."""
+        db = TelemetryDB(str(tmp_path / "t.db"))
+        db.open()
+        try:
+            bucket = 4 * 3600 * 1_000_000_000
+            base = (time.time_ns() // bucket) * bucket + 1_000_000
+            db.insert_get_terminal(base, "loc", "p", "c", "success", False, 0, 1, 0.0)
+            db.insert_get_terminal(base + 1, "net1", "p", "c", "success", False, 1, 2, 40.0)
+            db.insert_get_terminal(base + 2, "net9", "p", "c", "not_found", False, 9, 4, 900.0)
+            db.insert_get_terminal(base + 3, "unk", "p", "c", "success", False, None, None, 0.0)
+            db.flush()
+
+            rows = {(r[1], r[3]): r[4]
+                    for r in db.get_terminal_buckets(base - bucket, bucket)}
+            assert rows == {
+                ("success", "local"): 1,      # attempts=0 never left the machine
+                ("success", "network"): 1,    # attempts=1 routed to one peer
+                ("not_found", "network"): 1,  # attempts=9 routed to nine
+                ("success", "unknown"): 1,    # attempts absent: unmeasured
+            }
+        finally:
+            db.close()
+
+    def test_route_class_helper_matches_the_sql(self, tmp_path):
+        """The live counters classify in Python and the rebuild classifies in
+        SQL. If they disagree, a restart silently rewrites history."""
+        db = TelemetryDB(str(tmp_path / "t.db"))
+        db.open()
+        try:
+            bucket = 4 * 3600 * 1_000_000_000
+            base = (time.time_ns() // bucket) * bucket + 1_000_000
+            for i, attempts in enumerate([0, 1, 2, 17, None]):
+                db.insert_get_terminal(base + i, f"t{i}", "p", "c", "success",
+                                       False, attempts, 1, 0.0)
+            db.flush()
+            by_tx = {r[0]: r[1] for r in db.conn.execute(
+                f"SELECT tx_id, {TelemetryDB.ROUTE_CLASS_SQL} FROM get_terminals")}
+            for i, attempts in enumerate([0, 1, 2, 17, None]):
+                assert by_tx[f"t{i}"] == TelemetryDB.route_class(attempts), (
+                    f"SQL and Python disagree for attempts={attempts}"
+                )
         finally:
             db.close()
 
@@ -269,8 +317,9 @@ class TestGetTerminalsNeedsNoIndex:
                                        i % 3 == 0, 0, 2, 5.0)
             db.flush()
             rows = db.get_terminal_buckets(base - bucket, bucket)
-            assert sum(r[3] for r in rows) == 50
+            assert sum(r[4] for r in rows) == 50
             assert {r[1] for r in rows} == {"success", "not_found"}
+            assert {r[3] for r in rows} == {"local"}, "inserted with attempts=0"
         finally:
             db.close()
 

--- a/tests/test_get_health_metrics.py
+++ b/tests/test_get_health_metrics.py
@@ -354,6 +354,58 @@ class TestLocalHitsDoNotDiluteTheRoutedRate:
         assert live["get_local_n"] == 300
 
 
+class TestTheHeadlineSumsCountsNotRates:
+    """The 24h headline aggregates buckets, and a sparse bucket publishes
+    `get_routed_rate: None` (below METRICS_MIN_SAMPLES) while its volume is
+    still real. Reconstructing successes as `n * rate/100` dropped those
+    successes and kept their n, understating the headline — a true 100% read
+    as 87%, worst during exactly the quiet periods this metric should catch.
+    The server therefore publishes the exact numerator.
+    """
+
+    def test_the_exact_routed_success_count_is_published(self, srv):
+        t = time.time_ns()
+        for i in range(3):
+            feed(srv, "get_terminal", t + i, tx_id=f"ok-{i}",
+                 outcome="success", attempts=2)
+        feed(srv, "get_terminal", t + 100, tx_id="nf", outcome="not_found",
+             attempts=2)
+        point = series_of(srv)
+        assert point["get_routed_ok_n"] == 3
+        assert point["get_routed_n"] == 4
+
+    def test_a_sparse_bucket_publishes_counts_even_with_no_rate(self, srv):
+        """Two routed GETs is under METRICS_MIN_SAMPLES, so no rate — but the
+        counts must survive, or the headline loses them."""
+        t = time.time_ns()
+        for i in range(2):
+            feed(srv, "get_terminal", t + i, tx_id=f"ok-{i}",
+                 outcome="success", attempts=2)
+        point = series_of(srv)
+        assert point["get_routed_rate"] is None, "too few samples for a rate"
+        assert point["get_routed_ok_n"] == 2, "successes vanished with the rate"
+        assert point["get_routed_n"] == 2
+
+    def test_the_client_does_not_invert_the_rate_to_get_successes(self):
+        """js/metrics.js must sum get_routed_ok_n, not n * rate / 100."""
+        import os
+        js = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                          "js", "metrics.js")
+        with open(js, encoding="utf-8") as f:
+            src = f.read()
+        head, _, body = src.partition("function recentGetTotals")
+        assert body, "recentGetTotals moved; this pin no longer bounds anything"
+        body = body[:body.index("\n}")]
+        assert "p.get_routed_ok_n" in body
+        # Match the property ACCESS, not the bare word: the body explains in a
+        # comment why the rate must not be used, and a needle that its own
+        # explanation satisfies would fire on the fixed code.
+        assert "p.get_routed_rate" not in body, (
+            "the headline is reconstructing successes from a rounded, "
+            "sometimes-null rate again"
+        )
+
+
 class TestTheSplitterChoiceIsRecordedAndDefensible:
     """freenet-core #4852 P2 switched its OWN split from `attempts` to
     `hop_count`, because a loopback LocalCompletion bumps `requests_sent`
@@ -382,20 +434,28 @@ class TestTheSplitterChoiceIsRecordedAndDefensible:
                 f"({needle!r}) is no longer recorded beside the classifier"
             )
 
-    def test_a_zero_millisecond_success_at_attempts_one_would_be_a_loopback(self, srv):
-        """The shape that would invalidate the choice, asserted as a live check.
+    def test_classification_follows_attempts_and_ignores_latency(self, srv):
+        """Latency is the EVIDENCE for the choice, never the rule applied.
 
-        This does not fail today — it documents what to look for. If real
-        traffic ever produces attempts>=1 successes at ~0 ms, they are loopback
-        completions and the routed rate is being inflated by them.
+        A reader of the rationale might reasonably think elapsed_ms is part of
+        the classifier. It is not, deliberately: latency is what we measured to
+        show the populations are clean, and baking a threshold into the code
+        would invent a second, unvalidated rule. So a 0 ms attempts=1 terminal
+        counts as ROUTED (this is the loopback shape core's #4852 warns about —
+        if production ever produces it, revisit the classifier) and a slow
+        attempts=0 terminal counts as LOCAL.
         """
         t = time.time_ns()
-        for i in range(10):
-            feed(srv, "get_terminal", t + i, tx_id=f"g-{i}",
+        for i in range(6):
+            feed(srv, "get_terminal", t + i, tx_id=f"fast-{i}",
                  outcome="success", attempts=1, elapsed_ms=0)
-        # Counted as routed, because attempts says so. If production ever looks
-        # like this fixture, revisit the classifier — see telemetry_db.
-        assert series_of(srv)["get_routed_n"] == 10
+        for i in range(5):
+            feed(srv, "get_terminal", t + 100 + i, tx_id=f"slow-{i}",
+                 outcome="success", attempts=0, elapsed_ms=9000)
+
+        point = series_of(srv)
+        assert point["get_routed_n"] == 6, "0 ms did not make it local"
+        assert point["get_local_n"] == 5, "9 s did not make it routed"
 
 
 class TestOperationStatsSplitsLocalFromRouted:
@@ -414,6 +474,22 @@ class TestOperationStatsSplitsLocalFromRouted:
         assert stats["routed_success_rate"] == 11.1
         assert stats["local_hit_total"] == 200
         assert stats["local_hit_success"] == 200
+
+    def test_unclassified_terminals_do_not_leak_into_the_routed_rate(self, srv):
+        """Mutating _DIRECT_STAT_BUCKET to file unknown-attempts terminals as
+        routed left the whole suite green, so the stats path had no guard."""
+        t = time.time_ns()
+        for i in range(9):
+            feed(srv, "get_terminal", t + i, tx_id=f"u-{i}",
+                 outcome="success", attempts=None)
+        feed(srv, "get_terminal", t + 100, tx_id="nf", outcome="not_found",
+             attempts=2)
+
+        stats = srv.get_operation_stats()["get"]
+        assert stats["unclassified_total"] == 9
+        assert stats["routed_total"] == 1, "unclassified leaked into routed"
+        assert stats["routed_success_rate"] == 0.0
+        assert stats["local_hit_total"] == 0
 
     def test_timeouts_are_counted_separately_from_not_found(self, srv):
         t = time.time_ns()

--- a/tests/test_get_health_metrics.py
+++ b/tests/test_get_health_metrics.py
@@ -354,6 +354,50 @@ class TestLocalHitsDoNotDiluteTheRoutedRate:
         assert live["get_local_n"] == 300
 
 
+class TestTheSplitterChoiceIsRecordedAndDefensible:
+    """freenet-core #4852 P2 switched its OWN split from `attempts` to
+    `hop_count`, because a loopback LocalCompletion bumps `requests_sent`
+    without a network round-trip. The `attempts` doc comment core exports was
+    never updated and still recommends the split core abandoned.
+
+    We still split on `attempts`, because hop_count is not populated in this
+    telemetry (224,736 NULL / 242 zero / 2 non-zero over ~24h) and because the
+    loopback case is empirically absent — the populations separate by latency
+    with an empty band between them. That is a real judgement against a real
+    counter-argument, so it is written down where the next person will look.
+    """
+
+    def test_the_hop_count_rationale_is_recorded_next_to_the_classifier(self):
+        import inspect
+
+        import telemetry_db
+        src = inspect.getsource(telemetry_db)
+        head, _, tail = src.partition("ROUTE_CLASS_SQL = (")
+        assert tail, "ROUTE_CLASS_SQL moved; this pin no longer bounds anything"
+        # Bound the search to the comment block immediately above the constant.
+        block = head[head.rindex("ROUTE_LOCAL"):]
+        for needle in ("hop_count", "4852", "LocalCompletion"):
+            assert needle in block, (
+                f"the reason we split on attempts rather than hop_count "
+                f"({needle!r}) is no longer recorded beside the classifier"
+            )
+
+    def test_a_zero_millisecond_success_at_attempts_one_would_be_a_loopback(self, srv):
+        """The shape that would invalidate the choice, asserted as a live check.
+
+        This does not fail today — it documents what to look for. If real
+        traffic ever produces attempts>=1 successes at ~0 ms, they are loopback
+        completions and the routed rate is being inflated by them.
+        """
+        t = time.time_ns()
+        for i in range(10):
+            feed(srv, "get_terminal", t + i, tx_id=f"g-{i}",
+                 outcome="success", attempts=1, elapsed_ms=0)
+        # Counted as routed, because attempts says so. If production ever looks
+        # like this fixture, revisit the classifier — see telemetry_db.
+        assert series_of(srv)["get_routed_n"] == 10
+
+
 class TestOperationStatsSplitsLocalFromRouted:
     def test_local_hits_are_not_in_the_routed_rate(self, srv):
         t = time.time_ns()

--- a/tests/test_get_health_metrics.py
+++ b/tests/test_get_health_metrics.py
@@ -1,10 +1,23 @@
-"""Regression tests for issue #15 — GET health must come from get_terminal.
+"""Regression tests for the two ways the GET success rate has been wrong.
 
-`get_request` and `get_not_found` are emitted once per HOP, so their ratio
-tracks route length rather than user-visible success. Deriving the Performance
-chart's GET line from them understated success by roughly 600x during the
-2026-07-26 growth surge: the chart read 0.05-0.24% while the client-facing rate
-measured from get_terminal was 86.8-92.2%.
+issue #15 — GET health must come from get_terminal.
+    `get_request` and `get_not_found` are emitted once per HOP, so their ratio
+    tracks route length rather than user-visible success. Deriving the
+    Performance chart's GET line from them understated success by roughly 600x
+    during the 2026-07-26 growth surge: the chart read 0.05-0.24% while the
+    client-facing rate measured from get_terminal was 86.8-92.2%.
+
+2026-08-08 — the rate must cover only GETs that actually ROUTED.
+    get_terminal carries `attempts`, and attempts == 0 means the GET was served
+    from the local store without ever contacting a peer. Those cannot fail:
+    213,787 of them in 24h, 100.00% success, 0 ms at p50/p90/p99. They were 95%
+    of the denominator, so the published rate read 95.4% while network-routed
+    GET success was 8.46% (n=11,190; not_found 74.2%, timeout_exhausted 17.3%).
+    Confirmed independently against 26 GB of raw OTLP log: 8.35% routed
+    (271/3,247), 100.00% local (57,756/57,756), 95.12% blended.
+
+    A metric that reads ~95% whether or not the network can serve a request is
+    not a network metric. The classes are counted and published separately.
 """
 import time
 
@@ -12,6 +25,17 @@ from conftest import make_record
 
 
 def feed(srv, event_type, ts, tx_id=None, **body):
+    """Feed one event.
+
+    get_terminal defaults to `attempts=1` — a GET that routed to exactly one
+    peer — because every test below is about network-visible GET behaviour.
+    Tests covering local hits pass attempts=0 explicitly; tests covering the
+    unclassifiable case pass attempts=None. The default is deliberate rather
+    than incidental: an omitted `attempts` is a distinct third case, and a
+    fixture that silently produced it would leave the routed rate at None.
+    """
+    if event_type == "get_terminal" and "attempts" not in body:
+        body["attempts"] = 1
     srv.process_record(make_record(event_type, ts, tx_id=tx_id, **body))
 
 
@@ -32,11 +56,11 @@ class TestGetSuccessRateIgnoresPerHopEvents:
                  outcome="success", is_sub_op=False, elapsed_ms=12)
 
         point = series_of(srv)
-        assert point["get_rate"] == 100.0, (
+        assert point["get_routed_rate"] == 100.0, (
             "GET success rate was contaminated by per-hop routing events "
-            f"(got {point['get_rate']}%)"
+            f"(got {point['get_routed_rate']}%)"
         )
-        assert point["get_n"] == 20
+        assert point["get_routed_n"] == 20
         # The hop volume is still reported, just not as a success signal.
         assert point["get_hops_n"] == 1000
 
@@ -52,8 +76,8 @@ class TestGetSuccessRateIgnoresPerHopEvents:
                  outcome="not_found", is_sub_op=False)
 
         point = series_of(srv)
-        assert point["get_rate"] == 80.0
-        assert point["get_n"] == 10
+        assert point["get_routed_rate"] == 80.0
+        assert point["get_routed_n"] == 10
 
     def test_hop_success_events_do_not_inflate_the_denominator(self, srv):
         t = time.time_ns()
@@ -62,7 +86,7 @@ class TestGetSuccessRateIgnoresPerHopEvents:
                  outcome="success", is_sub_op=False)
         for i in range(50):
             feed(srv, "get_success", t + 1000 + i, tx_id=f"hop-{i}")
-        assert series_of(srv)["get_n"] == 6
+        assert series_of(srv)["get_routed_n"] == 6
 
 
 class TestSubOperationGetsAreVisible:
@@ -81,9 +105,9 @@ class TestSubOperationGetsAreVisible:
                  outcome="success", is_sub_op=True)
 
         point = series_of(srv)
-        assert point["get_rate"] == 100.0, "direct GETs were healthy"
+        assert point["get_routed_rate"] == 100.0, "direct GETs were healthy"
         assert point["get_sub_rate"] == 20.0, "sub-op failures must stay visible"
-        assert point["get_n"] == 10
+        assert point["get_routed_n"] == 10
         assert point["get_sub_n"] == 10
 
     def test_sub_op_failures_do_not_drag_down_the_direct_rate(self, srv):
@@ -94,7 +118,7 @@ class TestSubOperationGetsAreVisible:
         for i in range(6):
             feed(srv, "get_terminal", t + 100 + i, tx_id=f"s-{i}",
                  outcome="timeout_exhausted", is_sub_op=True)
-        assert series_of(srv)["get_rate"] == 100.0
+        assert series_of(srv)["get_routed_rate"] == 100.0
 
 
 class TestOperationStatsPanel:
@@ -109,12 +133,26 @@ class TestOperationStatsPanel:
              is_sub_op=False)
 
         stats = srv.get_operation_stats()["get"]
-        assert stats["success_rate"] == 90.0
-        assert stats["total"] == 10
-        assert stats["not_found"] == 1
+        assert stats["routed_success_rate"] == 90.0
+        assert stats["routed_total"] == 10
+        assert stats["routed_not_found"] == 1
         # Hop counters survive under names that cannot be read as an outcome.
         assert stats["hop_not_found"] == 200
         assert "requests" not in stats
+
+    def test_no_key_carries_a_rate_without_naming_its_population(self, srv):
+        """A bare `success_rate`/`total` is how the local-hit blend shipped.
+
+        Any consumer reading an unqualified key gets nothing rather than a
+        number whose scope it has guessed wrong.
+        """
+        t = time.time_ns()
+        feed(srv, "get_terminal", t, tx_id="ok", outcome="success")
+        stats = srv.get_operation_stats()["get"]
+        for bare in ("success_rate", "total", "not_found"):
+            assert bare not in stats, (
+                f"{bare!r} does not say which GETs it covers"
+            )
 
     def test_sub_op_rate_is_exposed(self, srv):
         t = time.time_ns()
@@ -139,9 +177,9 @@ class TestOperationStatsPanel:
             feed(srv, "get_terminal", t + 1000 + i, tx_id=f"none-{i}", is_sub_op=False)
 
         stats = srv.get_operation_stats()["get"]
-        assert stats["total"] == 6, "outcome-less terminals must not be counted"
-        assert stats["success_rate"] == 100.0
-        assert series_of(srv)["get_rate"] == 100.0
+        assert stats["routed_total"] == 6, "outcome-less terminals must not be counted"
+        assert stats["routed_success_rate"] == 100.0
+        assert series_of(srv)["get_routed_rate"] == 100.0
 
     def test_unknown_outcome_counts_without_inflating_success(self, srv):
         t = time.time_ns()
@@ -149,8 +187,8 @@ class TestOperationStatsPanel:
             feed(srv, "get_terminal", t + i, tx_id=f"w-{i}",
                  outcome="something_new", is_sub_op=False)
         stats = srv.get_operation_stats()["get"]
-        assert stats["total"] == 5
-        assert stats["success_rate"] == 0.0
+        assert stats["routed_total"] == 5
+        assert stats["routed_success_rate"] == 0.0
 
     def test_latency_still_measured_from_request_to_success(self, srv):
         """get_terminal reports elapsed_ms=0 on 99.5% of successful direct GETs,
@@ -176,7 +214,174 @@ class TestOperationStatsPanel:
         assert srv.get_operation_stats()["get"]["latency"]["p50"] == 40
         assert series_of(srv)["lat_get"] == 40
         # ...while the success rate is still measured from those terminals.
-        assert series_of(srv)["get_rate"] == 100.0
+        assert series_of(srv)["get_routed_rate"] == 100.0
+
+
+class TestLocalHitsDoNotDiluteTheRoutedRate:
+    """The 2026-08-08 defect, in production proportions.
+
+    Every test here fails if the attempts split is removed, and the first one
+    fails with the exact number the dashboard was publishing.
+    """
+
+    def feed_production_shape(self, srv):
+        """24h of real traffic, scaled 1:20.
+
+        Routed success lands on 8.4% here against 8.46% in the 24h to
+        2026-08-08; blending the local hits back in gives 95.4%, which is what
+        the dashboard was publishing.
+        """
+        t = time.time_ns()
+        n = 0
+
+        def add(count, **body):
+            nonlocal n
+            for _ in range(count):
+                feed(srv, "get_terminal", t + n, tx_id=f"g-{n}", **body)
+                n += 1
+
+        add(10689, outcome="success", attempts=0)            # local hits
+        add(47, outcome="success", attempts=3)               # routed successes
+        add(415, outcome="not_found", attempts=6)
+        add(97, outcome="timeout_exhausted", attempts=9)
+        return series_of(srv)
+
+    def test_routed_rate_is_not_propped_up_by_local_hits(self, srv):
+        point = self.feed_production_shape(srv)
+        assert point["get_routed_rate"] == 8.4, (
+            "local-store hits cannot fail, so including them in the denominator "
+            "publishes cache-hit share as network health — this read 95.4%"
+        )
+        assert point["get_routed_n"] == 559
+
+    def test_the_blended_rate_is_not_published_at_all(self, srv):
+        """Guards against a 'fix' that renames the blend instead of splitting."""
+        point = self.feed_production_shape(srv)
+        blended = round(10736 / 11248 * 100, 1)   # 95.4
+        assert blended not in [
+            v for k, v in point.items()
+            if k.endswith("_rate") and v is not None
+        ], "some published rate is still the local+routed blend"
+
+    def test_local_hits_are_still_reported_as_what_they_are(self, srv):
+        point = self.feed_production_shape(srv)
+        assert point["get_local_n"] == 10689
+        assert point["get_local_ok"] == 10689
+
+    def test_routed_failures_are_split_by_cause(self, srv):
+        """not_found means findability; timeout means routing/transport. A
+        single failure count cannot tell an operator which one to chase."""
+        point = self.feed_production_shape(srv)
+        assert point["get_routed_nf_n"] == 415
+        assert point["get_routed_timeout_n"] == 97
+
+    def test_a_healthy_cache_cannot_mask_a_dead_network(self, srv):
+        """The scenario the old metric was structurally unable to show."""
+        t = time.time_ns()
+        for i in range(5000):
+            feed(srv, "get_terminal", t + i, tx_id=f"loc-{i}",
+                 outcome="success", attempts=0)
+        for i in range(100):
+            feed(srv, "get_terminal", t + 10000 + i, tx_id=f"net-{i}",
+                 outcome="not_found", attempts=4)
+
+        point = series_of(srv)
+        assert point["get_routed_rate"] == 0.0, "every routed GET failed"
+        assert point["get_local_n"] == 5000
+
+    def test_a_local_only_window_reports_no_routed_rate_rather_than_100(self, srv):
+        """No routed GETs means the network was not measured. Reporting 100%
+        off the back of cache hits is the failure mode in miniature."""
+        t = time.time_ns()
+        for i in range(400):
+            feed(srv, "get_terminal", t + i, tx_id=f"loc-{i}",
+                 outcome="success", attempts=0)
+        point = series_of(srv)
+        assert point["get_routed_rate"] is None
+        assert point["get_routed_n"] == 0
+        assert point["get_local_n"] == 400
+
+    def test_attempts_of_one_counts_as_routed(self, srv):
+        """attempts=1 means the first peer answered — it still left the machine.
+        Only 0 is local; an off-by-one here would discard the majority of the
+        routed population."""
+        t = time.time_ns()
+        for i in range(10):
+            feed(srv, "get_terminal", t + i, tx_id=f"g-{i}",
+                 outcome="success", attempts=1)
+        assert series_of(srv)["get_routed_n"] == 10
+        assert series_of(srv)["get_local_n"] == 0
+
+    def test_missing_attempts_is_counted_apart_from_both(self, srv):
+        """Peers that stop reporting `attempts` must show up as unclassified,
+        not get silently folded into either population."""
+        t = time.time_ns()
+        for i in range(7):
+            feed(srv, "get_terminal", t + i, tx_id=f"u-{i}",
+                 outcome="success", attempts=None)
+        for i in range(6):
+            feed(srv, "get_terminal", t + 100 + i, tx_id=f"n-{i}",
+                 outcome="not_found", attempts=2)
+
+        point = series_of(srv)
+        assert point["get_unknown_n"] == 7
+        assert point["get_routed_n"] == 6
+        assert point["get_routed_rate"] == 0.0, "unclassified must not count as success"
+        assert point["get_local_n"] == 0
+
+    def test_the_split_survives_a_restart(self, srv):
+        """The rebuild classifies in SQL and the live path in Python. If they
+        drift, the dashboard changes its story when the server restarts."""
+        t = time.time_ns()
+        samples = ([("success", 0)] * 300 + [("success", 2)] * 4
+                   + [("not_found", 5)] * 40 + [("timeout_exhausted", 9)] * 6
+                   + [("success", None)] * 3)
+        for i, (outcome, attempts) in enumerate(samples):
+            feed(srv, "get_terminal", t + i, tx_id=f"g-{i}",
+                 outcome=outcome, attempts=attempts)
+        live = series_of(srv)
+
+        srv.db.flush()
+        srv.metrics_buckets.clear()
+        srv._current_bucket = None
+        srv.precompute_metrics_from_db()
+        rebuilt = series_of(srv)
+
+        for key in ("get_routed_rate", "get_routed_n", "get_local_n",
+                    "get_unknown_n", "get_routed_nf_n", "get_routed_timeout_n"):
+            assert live[key] == rebuilt[key], f"{key} changed across a restart"
+        assert live["get_routed_n"] == 50
+        assert live["get_local_n"] == 300
+
+
+class TestOperationStatsSplitsLocalFromRouted:
+    def test_local_hits_are_not_in_the_routed_rate(self, srv):
+        t = time.time_ns()
+        for i in range(200):
+            feed(srv, "get_terminal", t + i, tx_id=f"loc-{i}",
+                 outcome="success", attempts=0)
+        for i in range(8):
+            feed(srv, "get_terminal", t + 1000 + i, tx_id=f"nf-{i}",
+                 outcome="not_found", attempts=3)
+        feed(srv, "get_terminal", t + 2000, tx_id="ok", outcome="success", attempts=3)
+
+        stats = srv.get_operation_stats()["get"]
+        assert stats["routed_total"] == 9
+        assert stats["routed_success_rate"] == 11.1
+        assert stats["local_hit_total"] == 200
+        assert stats["local_hit_success"] == 200
+
+    def test_timeouts_are_counted_separately_from_not_found(self, srv):
+        t = time.time_ns()
+        for i in range(4):
+            feed(srv, "get_terminal", t + i, tx_id=f"to-{i}",
+                 outcome="timeout_exhausted", attempts=9)
+        for i in range(3):
+            feed(srv, "get_terminal", t + 100 + i, tx_id=f"nf-{i}",
+                 outcome="not_found", attempts=9)
+        stats = srv.get_operation_stats()["get"]
+        assert stats["routed_timeout_exhausted"] == 4
+        assert stats["routed_not_found"] == 3
 
 
 class TestSubscribeHasNoSuccessRate:
@@ -269,8 +474,8 @@ class TestPrecomputeRebuildsEveryOutcome:
             + [("not_found", False)] * 2
             + [("timeout_exhausted", False)] * 1
         ))
-        assert point["get_rate"] == 70.0, "non-success outcomes were counted as success"
-        assert point["get_n"] == 10
+        assert point["get_routed_rate"] == 70.0, "non-success outcomes were counted as success"
+        assert point["get_routed_n"] == 10
 
     def test_rebuild_keeps_sub_ops_separate(self, srv):
         point = self.feed_and_rebuild(srv, (
@@ -278,9 +483,9 @@ class TestPrecomputeRebuildsEveryOutcome:
             + [("timeout_exhausted", True)] * 8
             + [("success", True)] * 2
         ))
-        assert point["get_rate"] == 100.0, "direct GETs were healthy"
+        assert point["get_routed_rate"] == 100.0, "direct GETs were healthy"
         assert point["get_sub_rate"] == 20.0, "sub-op failures must survive a restart"
-        assert point["get_n"] == 6
+        assert point["get_routed_n"] == 6
         assert point["get_sub_n"] == 10
 
     def test_rebuild_matches_the_live_path(self, srv):
@@ -299,5 +504,5 @@ class TestPrecomputeRebuildsEveryOutcome:
         srv.precompute_metrics_from_db()
         rebuilt = srv.get_metrics_timeseries()["series"][-1]
 
-        for key in ("get_rate", "get_sub_rate", "get_n", "get_sub_n"):
+        for key in ("get_routed_rate", "get_sub_rate", "get_routed_n", "get_sub_n"):
             assert live[key] == rebuilt[key], f"{key} changed across a restart"

--- a/tests/test_metrics_chart_contract.py
+++ b/tests/test_metrics_chart_contract.py
@@ -21,11 +21,19 @@ def js_source():
 
 
 def series_keys_read_by_client():
-    """Keys pulled off a series point: `series.map(p => p.foo)` and, inside the
-    tooltip, `s.foo` where `const s = series[idx]`."""
+    """Every key the chart pulls off a series point.
+
+    Matches any `p.foo` / `s.foo` access, because those are the two names the
+    client binds a series point to (`series.map(p => ...)`, and `const s =
+    series[idx]` in the tooltip). An earlier version matched only the two
+    specific SHAPES `p => p.foo` and `count = s.foo`, which silently missed
+    every key read any other way — `get_local_n`, `get_unknown_n`,
+    `get_routed_nf_n` and `get_routed_timeout_n` were all invisible to it, so
+    the guard against exactly this drift was vacuous for the fields that needed
+    it most. Deleting the JS that reads `get_local_n` left the suite green.
+    """
     src = js_source()
-    keys = set(re.findall(r"p\s*=>\s*p\.([a-z_]+)", src))
-    keys |= set(re.findall(r"\bcount\s*=\s*s\.([a-z_]+)", src))
+    keys = set(re.findall(r"\b[ps]\.([a-z_]{3,})\b", src))
     assert keys, "the extraction regex matched nothing — it has drifted"
     return keys
 
@@ -44,6 +52,11 @@ def test_every_series_key_the_chart_reads_is_emitted(srv):
 @pytest.mark.parametrize("key", [
     "get_routed_rate", "get_sub_rate", "put_rate", "upd_rate",
     "get_routed_n", "get_sub_n", "put_n", "upd_n",
+    # The headline sums these directly; get_routed_ok_n in particular must be
+    # published, because reconstructing it from get_routed_rate loses every
+    # bucket below METRICS_MIN_SAMPLES.
+    "get_routed_ok_n", "get_routed_nf_n", "get_routed_timeout_n",
+    "get_local_n", "get_local_ok", "get_unknown_n",
 ])
 def test_chart_keys_are_present(srv, key):
     t = time.time_ns()

--- a/tests/test_metrics_chart_contract.py
+++ b/tests/test_metrics_chart_contract.py
@@ -42,8 +42,8 @@ def test_every_series_key_the_chart_reads_is_emitted(srv):
 
 
 @pytest.mark.parametrize("key", [
-    "get_rate", "get_sub_rate", "put_rate", "upd_rate",
-    "get_n", "get_sub_n", "put_n", "upd_n",
+    "get_routed_rate", "get_sub_rate", "put_rate", "upd_rate",
+    "get_routed_n", "get_sub_n", "put_n", "upd_n",
 ])
 def test_chart_keys_are_present(srv, key):
     t = time.time_ns()

--- a/tests/test_transaction_payloads.py
+++ b/tests/test_transaction_payloads.py
@@ -105,13 +105,14 @@ class TestGetTerminalsPersistEndToEnd:
         t = time.time_ns()
         for i in range(6):
             srv.process_record(make_record("get_terminal", t + i, tx_id=f"g-{i}",
-                                           outcome="success", is_sub_op=False))
+                                           outcome="success", is_sub_op=False,
+                                           attempts=1))
         srv.db.flush()
         # Wipe the in-memory buckets: this is the post-restart path.
         srv.metrics_buckets.clear()
         srv._current_bucket = None
         srv.precompute_metrics_from_db()
-        assert srv.get_metrics_timeseries()["series"][-1]["get_rate"] == 100.0
+        assert srv.get_metrics_timeseries()["series"][-1]["get_routed_rate"] == 100.0
 
     @pytest.mark.parametrize("outcome", ["success", "not_found", "timeout_exhausted"])
     def test_no_row_is_written_without_an_outcome(self, srv, outcome):

--- a/ws_server.py
+++ b/ws_server.py
@@ -510,16 +510,38 @@ def get_propagation_data():
 #   term_*                         — client-facing outcomes from get_terminal,
 #                                    split by direct vs sub-operation. These are
 #                                    the only ones a success rate may use.
+#
+# `term_direct` is split AGAIN, by whether the GET actually routed:
+#   term_direct_net — attempts >= 1. Left the machine, so it could fail. This is
+#                     the network-health population and the only honest headline.
+#   term_direct_loc — attempts == 0. Served from the local store; cannot fail,
+#                     and was 95% of direct GETs on 2026-08-08. A rate over
+#                     net+loc read 95.4% while the routed rate was 8.5%.
+#   term_direct_unk — attempts absent. Measured neither, so it is reported as
+#                     its own count rather than folded into either rate.
 op_stats = {
     "put": {"requests": 0, "successes": 0, "latencies": []},
     "get": {
         "hop_requests": 0, "hop_not_found": 0,
-        "term_direct": {"success": 0, "not_found": 0, "other": 0},
-        "term_sub_op": {"success": 0, "not_found": 0, "other": 0},
+        "term_direct_net": {"success": 0, "not_found": 0,
+                            "timeout_exhausted": 0, "other": 0},
+        "term_direct_loc": {"success": 0, "not_found": 0,
+                            "timeout_exhausted": 0, "other": 0},
+        "term_direct_unk": {"success": 0, "not_found": 0,
+                            "timeout_exhausted": 0, "other": 0},
+        "term_sub_op": {"success": 0, "not_found": 0,
+                        "timeout_exhausted": 0, "other": 0},
         "latencies": [],
     },
     "update": {"requests": 0, "successes": 0, "broadcasts": 0, "latencies": []},
     "subscribe": {"requests": 0, "successes": 0, "not_found": 0, "timeouts": 0},
+}
+
+# TelemetryDB.route_class(...) -> the op_stats["get"] sub-dict it belongs in.
+_DIRECT_STAT_BUCKET = {
+    TelemetryDB.ROUTE_NETWORK: "term_direct_net",
+    TelemetryDB.ROUTE_LOCAL: "term_direct_loc",
+    TelemetryDB.ROUTE_UNKNOWN: "term_direct_unk",
 }
 
 # ── Time-series metrics (4-hour buckets, kept for 8 days) ──
@@ -532,7 +554,7 @@ METRICS_MIN_SAMPLES = 5  # Minimum ops in a bucket to compute a meaningful rate
 # axis and squeezes all real data into a sliver at one edge.
 METRICS_MAX_FUTURE_SKEW_NS = 60 * 60 * 1_000_000_000  # 1 hour
 # Each bucket: {ts, put_req, put_ok, get_req, get_nf (per-HOP volume),
-#               gt_ok/gt_bad + gt_sub_ok/gt_sub_bad (client-facing GET outcomes),
+#               gt (client-facing GET outcomes, keyed by population),
 #               upd_req, upd_ok, sub_ok, sub_bad, peers, lat_put, lat_get, lat_upd}
 metrics_buckets = {}       # bucket_key -> bucket dict (dict for O(1) lookup by timestamp)
 _current_bucket = None     # the bucket we're currently filling
@@ -572,9 +594,14 @@ def _get_or_create_bucket(timestamp_ns):
         "put_req": 0, "put_ok": 0,
         # get_req/get_nf are per-HOP counts, kept for routing volume only.
         "get_req": 0, "get_nf": 0,
-        # Client-facing GET outcomes from get_terminal, split direct vs sub-op.
-        "gt_ok": 0, "gt_bad": 0,
-        "gt_sub_ok": 0, "gt_sub_bad": 0,
+        # Client-facing GET outcomes from get_terminal, as a
+        # (population, outcome) -> count map. `population` is one of
+        # direct_network / direct_local / direct_unknown / sub_op_*, i.e. the
+        # direct-vs-sub-op split crossed with TelemetryDB.route_class. Kept as
+        # one map rather than a fixed set of gt_* scalars so that adding an
+        # outcome cannot silently land in a bucket that already means something
+        # else, and so the populations always sum back to the raw event count.
+        "gt": {},
         "upd_req": 0, "upd_ok": 0,
         "sub_ok": 0, "sub_bad": 0,
         "reporting_peers": set(),
@@ -587,12 +614,25 @@ def _get_or_create_bucket(timestamp_ns):
 _future_skew_drops = 0
 
 
+def gt_population(is_sub_op, attempts):
+    """Name the get_terminal population a sample belongs to.
+
+    Two independent splits, and both matter:
+      direct vs sub_op — whether a client asked for this GET at all.
+      network vs local — whether it was routed. A local hit (attempts == 0)
+                         never left the machine and has no failure mode, so it
+                         must not share a denominator with routed GETs.
+    """
+    kind = "sub_op" if is_sub_op else "direct"
+    return f"{kind}_{TelemetryDB.route_class(attempts)}"
+
+
 def record_metric(event_type, timestamp_ns, latency_ms=None, peer_id=None,
-                  outcome=None, is_sub_op=False):
+                  outcome=None, is_sub_op=False, attempts=None):
     """Record an operation into the current time bucket.
 
-    `outcome`/`is_sub_op` apply to get_terminal, the only GET event that
-    reports what the requesting client actually saw.
+    `outcome`/`is_sub_op`/`attempts` apply to get_terminal, the only GET event
+    that reports what the requesting client actually saw.
     """
     global _future_skew_drops
     if timestamp_ns - int(time.time() * 1_000_000_000) > METRICS_MAX_FUTURE_SKEW_NS:
@@ -619,11 +659,8 @@ def record_metric(event_type, timestamp_ns, latency_ms=None, peer_id=None,
         if latency_ms is not None:
             b["lat_get"].append(latency_ms)
     elif event_type == "get_terminal":
-        ok = outcome == "success"
-        if is_sub_op:
-            b["gt_sub_ok" if ok else "gt_sub_bad"] += 1
-        else:
-            b["gt_ok" if ok else "gt_bad"] += 1
+        key = (gt_population(is_sub_op, attempts), outcome)
+        b["gt"][key] = b["gt"].get(key, 0) + 1
     elif event_type == "update_request":
         b["upd_req"] += 1
     elif event_type == "update_success":
@@ -698,15 +735,16 @@ def precompute_metrics_from_db():
     # Client-facing GET outcomes come from their own table, which stores the
     # outcome and is_sub_op that tx_events cannot carry.
     try:
-        for bucket_ts, outcome, is_sub_op, count, _avg_ms in db.get_terminal_buckets(
+        for (bucket_ts, outcome, is_sub_op, route_class, count,
+             _avg_ms) in db.get_terminal_buckets(
                 cutoff_ns, METRICS_BUCKET_NS, until_ns=future_cutoff_ns):
             total_events += count
             b = _get_or_create_bucket(bucket_ts)
-            ok = outcome == "success"
-            if is_sub_op:
-                b["gt_sub_ok" if ok else "gt_sub_bad"] += count
-            else:
-                b["gt_ok" if ok else "gt_bad"] += count
+            # SQL already classified `attempts`; keep its answer rather than
+            # re-deriving one, so the rebuilt series cannot disagree with the
+            # live one about which GETs were routed.
+            key = (f"{'sub_op' if is_sub_op else 'direct'}_{route_class}", outcome)
+            b["gt"][key] = b["gt"].get(key, 0) + count
     except Exception as e:
         print(f"[metrics] get_terminal precompute skipped: {e}", flush=True)
 
@@ -736,17 +774,41 @@ def get_metrics_timeseries():
         b = metrics_buckets[key]
         put_total = b["put_req"] or b["put_ok"]
         upd_total = b["upd_req"] or b["upd_ok"]
+
         # GET success is measured from get_terminal only. Deriving it from the
         # per-hop get_success/get_not_found counts understated it by ~600x
         # during the 2026-07-26 growth surge (issue #15).
-        get_total = b["gt_ok"] + b["gt_bad"]
-        get_sub_total = b["gt_sub_ok"] + b["gt_sub_bad"]
+        #
+        # ...and then split by whether the GET was ROUTED. A local-store hit
+        # (attempts == 0) never touches the network and so cannot fail; it was
+        # 95% of direct GETs, which pinned the published rate near 95% while
+        # network-routed GET success sat at 8.5%. The routed population is the
+        # headline; the local one ships beside it as a cache-hit count, which is
+        # what it actually is.
+        gt = b["gt"]
+
+        def pop(population, outcome):
+            return gt.get((population, outcome), 0)
+
+        def pop_total(population):
+            return sum(n for (p, _o), n in gt.items() if p == population)
+
+        net_total = pop_total("direct_network")
+        loc_total = pop_total("direct_local")
+        unk_total = pop_total("direct_unknown")
+        get_sub_total = (pop_total("sub_op_network") + pop_total("sub_op_local")
+                         + pop_total("sub_op_unknown"))
+        sub_ok = (pop("sub_op_network", "success") + pop("sub_op_local", "success")
+                  + pop("sub_op_unknown", "success"))
 
         series.append({
             "t": b["ts"],
             "put_rate": rate_or_none(b["put_ok"], put_total),
-            "get_rate": rate_or_none(b["gt_ok"], get_total),
-            "get_sub_rate": rate_or_none(b["gt_sub_ok"], get_sub_total),
+            # Deliberately NOT named get_rate. The old key meant "direct GETs,
+            # routed or not"; a consumer still reading it should break loudly
+            # rather than silently keep plotting a differently-scoped number.
+            "get_routed_rate": rate_or_none(pop("direct_network", "success"), net_total),
+            "get_sub_rate": rate_or_none(sub_ok, get_sub_total),
             "upd_rate": rate_or_none(b["upd_ok"], upd_total),
             # No sub_rate. SUBSCRIBE has no client-facing terminal event, so
             # subscribe_success/_not_found are minted per hop on the response
@@ -754,9 +816,23 @@ def get_metrics_timeseries():
             # made GET read 0.05% against a real 87% (issue #15). There is no
             # arithmetic that fixes it, so the counts ship without a rate.
             "put_n": put_total,
-            "get_n": get_total,
+            "get_routed_n": net_total,
             "get_sub_n": get_sub_total,
             "upd_n": upd_total,
+            # Why routed GETs failed. not_found and timeout_exhausted imply
+            # different problems (findability/placement vs routing/transport),
+            # so a single failure rate would average away which one is biting.
+            "get_routed_nf_n": pop("direct_network", "not_found"),
+            "get_routed_timeout_n": pop("direct_network", "timeout_exhausted"),
+            # Local-store hits: a CACHE-HIT count, not a network measure. Kept
+            # visible so the routed denominator's smallness is explicable
+            # (routed n is ~5% of client GETs) rather than looking like data loss.
+            "get_local_n": loc_total,
+            "get_local_ok": pop("direct_local", "success"),
+            # Terminals whose `attempts` was absent, so neither rate can claim
+            # them. Expected to be 0; a non-zero value means peers stopped
+            # reporting the field and the routed rate is undercounting.
+            "get_unknown_n": unk_total,
             # Per-hop volumes. Deliberately not success signals.
             "sub_hops_ok": b["sub_ok"],
             "sub_hops_bad": b["sub_bad"],
@@ -1693,10 +1769,18 @@ def process_record(record, store_history=True):
         # on it for the same reason, and the two must not disagree.
         _outcome = body["outcome"]
         _sub = bool(body.get("is_sub_op"))
-        _bucket = op_stats["get"]["term_sub_op" if _sub else "term_direct"]
+        # `attempts` decides whether this GET touched the network at all, so it
+        # has to reach the counters — a rate that cannot see it is the 95%-vs-8.5%
+        # defect. Read with .get(): absent means unmeasured, not zero, and zero
+        # is the meaningful value for a local hit.
+        _attempts = body.get("attempts")
+        _bucket = op_stats["get"][
+            "term_sub_op" if _sub else _DIRECT_STAT_BUCKET[
+                TelemetryDB.route_class(_attempts)]
+        ]
         _bucket[_outcome if _outcome in _bucket else "other"] += 1
         record_metric("get_terminal", timestamp, peer_id=event_peer_id,
-                      outcome=_outcome, is_sub_op=_sub)
+                      outcome=_outcome, is_sub_op=_sub, attempts=_attempts)
     elif event_type == "update_request":
         op_stats["update"]["requests"] += 1
         record_metric("update_request", timestamp, peer_id=event_peer_id)
@@ -2279,9 +2363,13 @@ def get_operation_stats():
     update = op_stats["update"]
     subscribe = op_stats["subscribe"]
 
-    direct = get["term_direct"]
+    net = get["term_direct_net"]
+    loc = get["term_direct_loc"]
+    unk = get["term_direct_unk"]
     sub_op = get["term_sub_op"]
-    direct_total = sum(direct.values())
+    net_total = sum(net.values())
+    loc_total = sum(loc.values())
+    unk_total = sum(unk.values())
     sub_op_total = sum(sub_op.values())
     return {
         "put": {
@@ -2289,13 +2377,24 @@ def get_operation_stats():
             "success_rate": calc_rate(put["successes"], put["requests"]),
             "latency": calc_percentiles(put["latencies"]),
         },
-        # GET rates are measured from get_terminal, the client-facing outcome.
-        # The per-hop counts are still reported, under names that cannot be
-        # mistaken for an outcome (issue #15).
+        # GET rates are measured from get_terminal, the client-facing outcome
+        # (issue #15), and only over ROUTED GETs. Every key that carries a rate
+        # names its population, because the un-named version of this — a plain
+        # `total`/`success_rate` over routed and local hits together — is what
+        # published 95% against a real 8.5%. The per-hop counts stay too, under
+        # names that cannot be mistaken for an outcome.
         "get": {
-            "total": direct_total,
-            "success_rate": calc_rate(direct["success"], direct_total) if direct_total else None,
-            "not_found": direct["not_found"],
+            "routed_total": net_total,
+            "routed_success_rate": calc_rate(net["success"], net_total) if net_total else None,
+            "routed_not_found": net["not_found"],
+            "routed_timeout_exhausted": net["timeout_exhausted"],
+            # Local-store hits. Reported as a count, not folded into any rate:
+            # these never reached the network, so they have no failure mode and
+            # measure cache behaviour rather than network health.
+            "local_hit_total": loc_total,
+            "local_hit_success": loc["success"],
+            # Terminals with no `attempts`; unclassifiable, so counted alone.
+            "unclassified_total": unk_total,
             "sub_op_total": sub_op_total,
             "sub_op_success_rate": calc_rate(sub_op["success"], sub_op_total) if sub_op_total else None,
             "hop_requests": get["hop_requests"],

--- a/ws_server.py
+++ b/ws_server.py
@@ -817,6 +817,14 @@ def get_metrics_timeseries():
             # arithmetic that fixes it, so the counts ship without a rate.
             "put_n": put_total,
             "get_routed_n": net_total,
+            # EXACT routed success count, not derivable from the rate above.
+            # The 24h headline sums raw counts across buckets, and a bucket
+            # below METRICS_MIN_SAMPLES publishes get_routed_rate=None while its
+            # volume is still real. Reconstructing successes as n * rate/100
+            # therefore dropped those buckets' successes while keeping their n,
+            # understating the headline (a true 100% reported as 87%). Publish
+            # the numerator so no consumer has to invert a rounded rate.
+            "get_routed_ok_n": pop("direct_network", "success"),
             "get_sub_n": get_sub_total,
             "upd_n": upd_total,
             # Why routed GETs failed. not_found and timeout_exhausted imply


### PR DESCRIPTION
## Problem

The Performance chart's GET line read **~95%** while network-routed GET success was **8.5%**. The metric could not have shown otherwise: ~95% of its denominator was operations with no failure mode.

`get_terminal` carries `attempts`, and the core defines `attempts == 0` as a local-store hit that never contacted a peer ([`GetEvent::ClientTerminal`](https://github.com/freenet/freenet-core/blob/main/crates/core/src/tracing/event_kind.rs) — "`0` is the convention for a LOCAL-cache hit that never routed to the network ... letting analysts split 'all client GET successes' from 'network GET findability'"). Those GETs cannot fail.

24h to 2026-08-08:

| population | n | success |
|---|---:|---:|
| local hit (`attempts == 0`) | 213,787 | 100.00% |
| **routed (`attempts >= 1`)** | **11,190** | **8.46%** |
| blended (what shipped) | 224,977 | 95.45% |

Corroborating: p50/p90/p99 latency of "successful" GETs was 0 ms and 99.6% finished under 10 ms — they never left the machine.

A number that reads 95% whether or not the network can serve a request cannot answer the only question the panel exists for.

## Approach

Split the populations; don't relabel the blend.

- `TelemetryDB.route_class()` / `ROUTE_CLASS_SQL` classify `attempts` once. The live path classifies in Python, the post-restart rebuild in SQL; sharing one definition is what stops a restart from rewriting history, and a test asserts the two agree.
- Metric buckets hold a `(population, outcome) -> count` map rather than four fixed `gt_*` scalars, so populations always sum back to the raw event count.
- Series publishes `get_routed_rate`/`get_routed_n` as the headline, `get_local_n`/`get_local_ok` beside it as the cache-hit count it always was, `get_routed_nf_n`/`get_routed_timeout_n` for the failure split, `get_unknown_n` for terminals with no `attempts`.
- **`get_rate` and `get_n` are removed, not redefined.** A consumer still reading them gets nothing, which is visible. Silently changing what a key means is not.
- `get_operation_stats()` carried the same blend over the websocket. Every rate-bearing key now names its population (`routed_success_rate`, `local_hit_total`); a test asserts no bare `success_rate`/`total` survives.

`not_found` and `timeout_exhausted` are reported apart because they imply different problems — findability/placement vs routing/transport. Over 24h routed failures were 74.2% not_found / 17.3% timeout, but the mix swings hard per 4h bucket (91.0% / 2.1% at 04:00 UTC on 08-08), which a single failure count would average away.

## Presentation

The Performance panel gains a summary above the chart: routed GET success for the last 24h with its failure split, and local cache hits and sub-op GETs listed separately as counts. The chart's GET line becomes "GET (routed)", its tooltip names the failure causes and the local-hit count, and a footnote states what the metric includes and excludes so the `attempts == 0` split doesn't have to be rediscovered.

## Testing

`TestLocalHitsDoNotDiluteTheRoutedRate` feeds 24h of production proportions scaled 1:20 and asserts 8.4%. Mutation-tested: folding local hits back into the denominator makes it fail with `assert 95.4 == 8.4` — the exact number that shipped — and takes 4 other tests with it.

Also covered: a healthy cache cannot mask a network where every routed GET fails; a local-only window reports *no* routed rate rather than 100%; `attempts == 1` counts as routed; a missing `attempts` is counted apart from both rather than folded into either; the split survives a restart.

**Verified against the raw OTLP log independently of the DB projection** (26 GB, ~6h, scanned without touching `telemetry.db`): 8.35% routed (271/3,247), 100.00% local (57,756/57,756), 95.12% blended. The DB agrees with the raw log on the failure mix over the same window.

154 tests pass.

## Deploying

The frontend is served straight from this checkout, but the backend change needs `freenet-dashboard-ws.service` restarted — and `tail_log()` does `f.seek(0, 2)` on start, so a restart drops every event written during the downtime (there is no offset persistence). `main` is intentionally left untouched until someone picks a moment for that.

[AI-assisted - Claude]
