### PR TITLE
fix: present PUT and UPDATE as hop volume, not as success rates

### DIFF
--- a/js/metrics.js
+++ b/js/metrics.js
@@ -210,8 +210,15 @@ export function initMetricsChart(container) {
     // near 95% while routed GETs were succeeding 8.5% of the time.
     const rawGet = series.map(p => p.get_routed_rate);
     const rawGetSub = series.map(p => p.get_sub_rate);
-    const rawPut = series.map(p => p.put_rate);
-    const rawUpd = series.map(p => p.upd_rate);
+    // PUT and UPDATE are per-HOP event VOLUME, on their own right-hand axis.
+    // They used to be plotted as "success %", which was not merely imprecise
+    // but inverted: UPDATE read 0.0-0.1% while updates propagated fine, and
+    // PUT computed up to 148.6% — drawn against a hardcoded max of 100, so it
+    // rendered pinned flat at the top and looked like perfect health. There is
+    // no honest rate to draw until the core emits a client-facing terminal for
+    // these ops (freenet-core#5250), so they ship as volume.
+    const rawPut = series.map(p => p.put_hops_n);
+    const rawUpd = series.map(p => p.upd_hops_n);
 
     // EMA-smoothed rates for display
     const smoothGet = ema(rawGet);
@@ -264,7 +271,9 @@ export function initMetricsChart(container) {
                     order: 1,
                 },
                 {
-                    label: 'PUT',
+                    // Volume, on the right-hand axis. Labelled "hops" so it
+                    // cannot be misread as an outcome.
+                    label: 'PUT hops',
                     data: smoothPut,
                     borderColor: C.put,
                     backgroundColor: C.put + '12',
@@ -274,12 +283,12 @@ export function initMetricsChart(container) {
                     pointHitRadius: 12,
                     tension: 0.35,
                     fill: true,
-                    yAxisID: 'y',
+                    yAxisID: 'yVol',
                     spanGaps: false,
                     order: 3,
                 },
                 {
-                    label: 'UPDATE',
+                    label: 'UPDATE hops',
                     data: smoothUpd,
                     borderColor: C.update,
                     backgroundColor: C.update + '12',
@@ -289,7 +298,7 @@ export function initMetricsChart(container) {
                     pointHitRadius: 12,
                     tension: 0.35,
                     fill: true,
-                    yAxisID: 'y',
+                    yAxisID: 'yVol',
                     spanGaps: false,
                     order: 4,
                 },
@@ -343,10 +352,19 @@ export function initMetricsChart(container) {
                             // Show raw (unsmoothed) value + sample count
                             const lbl = item.dataset.label;
                             let raw, count;
+                            // PUT/UPDATE are volume, so they report a count and
+                            // never a percentage — returning early keeps them out
+                            // of the "%" formatting below entirely.
+                            if (lbl === 'PUT hops') {
+                                return ` PUT: ${NUM.format(s.put_hops_n || 0)} hop events `
+                                     + `(${NUM.format(s.put_hops_ok || 0)} succeeded per-hop; not a client rate)`;
+                            }
+                            if (lbl === 'UPDATE hops') {
+                                return ` UPDATE: ${NUM.format(s.upd_hops_n || 0)} hop events `
+                                     + `(${NUM.format(s.upd_hops_ok || 0)} succeeded per-hop; not a client rate)`;
+                            }
                             if (lbl === 'GET (routed)') { raw = rawGet[idx]; count = s.get_routed_n; }
                             else if (lbl === 'GET (sub-op)') { raw = rawGetSub[idx]; count = s.get_sub_n; }
-                            else if (lbl === 'PUT') { raw = rawPut[idx]; count = s.put_n; }
-                            else if (lbl === 'UPDATE') { raw = rawUpd[idx]; count = s.upd_n; }
                             if (raw == null) return ` ${lbl}: insufficient data`;
                             const line = ` ${lbl}: ${raw}% (${count} ops)`;
                             if (lbl !== 'GET (routed)') return line;
@@ -385,13 +403,34 @@ export function initMetricsChart(container) {
                     },
                     border: { display: false },
                 },
+                yVol: {
+                    position: 'right',
+                    min: 0,
+                    // Deliberately uncapped: this is a count, and capping a
+                    // count is how the PUT line came to render 148.6% as a
+                    // flat, healthy-looking line against a hardcoded 100.
+                    title: {
+                        display: true,
+                        text: 'hop events',
+                        color: C.textMuted,
+                        font: { size: 9, family: "'IBM Plex Mono', monospace" },
+                    },
+                    grid: { display: false },
+                    ticks: {
+                        color: C.textMuted,
+                        font: { size: 9, family: "'IBM Plex Mono', monospace" },
+                        callback: v => (v >= 1000 ? (v / 1000) + 'k' : v),
+                        maxTicksLimit: 5,
+                    },
+                    border: { display: false },
+                },
                 y: {
                     position: 'left',
                     min: 0,
                     max: 100,
                     title: {
                         display: true,
-                        text: 'success %',
+                        text: 'GET success %',
                         color: C.textMuted,
                         font: { size: 9, family: "'IBM Plex Mono', monospace" },
                     },
@@ -427,8 +466,8 @@ export function updateMetricsChart() {
 
     const rawGet = series.map(p => p.get_routed_rate);
     const rawGetSub = series.map(p => p.get_sub_rate);
-    const rawPut = series.map(p => p.put_rate);
-    const rawUpd = series.map(p => p.upd_rate);
+    const rawPut = series.map(p => p.put_hops_n);
+    const rawUpd = series.map(p => p.upd_hops_n);
 
     // The summary above the chart is a 24h aggregate, so it has to be rebuilt
     // on refresh too — a stale headline is the failure mode this panel is
@@ -443,8 +482,8 @@ export function updateMetricsChart() {
     const byLabel = {
         'GET (routed)': rawGet,
         'GET (sub-op)': rawGetSub,
-        'PUT': rawPut,
-        'UPDATE': rawUpd,
+        'PUT hops': rawPut,
+        'UPDATE hops': rawUpd,
     };
     for (const ds of chart.data.datasets) {
         if (byLabel[ds.label]) ds.data = ema(byLabel[ds.label]);

--- a/js/metrics.js
+++ b/js/metrics.js
@@ -356,12 +356,14 @@ export function initMetricsChart(container) {
                             // never a percentage — returning early keeps them out
                             // of the "%" formatting below entirely.
                             if (lbl === 'PUT hops') {
-                                return ` PUT: ${NUM.format(s.put_hops_n || 0)} hop events `
-                                     + `(${NUM.format(s.put_hops_ok || 0)} succeeded per-hop; not a client rate)`;
+                                return ` PUT: ${NUM.format(s.put_hops_n || 0)} put_request, `
+                                     + `${NUM.format(s.put_hops_ok || 0)} put_success — separate per-hop`
+                                     + ` counters, not a numerator over a denominator`;
                             }
                             if (lbl === 'UPDATE hops') {
-                                return ` UPDATE: ${NUM.format(s.upd_hops_n || 0)} hop events `
-                                     + `(${NUM.format(s.upd_hops_ok || 0)} succeeded per-hop; not a client rate)`;
+                                return ` UPDATE: ${NUM.format(s.upd_hops_n || 0)} update_request, `
+                                     + `${NUM.format(s.upd_hops_ok || 0)} update_success — separate per-hop`
+                                     + ` counters, not a numerator over a denominator`;
                             }
                             if (lbl === 'GET (routed)') { raw = rawGet[idx]; count = s.get_routed_n; }
                             else if (lbl === 'GET (sub-op)') { raw = rawGetSub[idx]; count = s.get_sub_n; }

--- a/tests/test_get_health_metrics.py
+++ b/tests/test_get_health_metrics.py
@@ -504,6 +504,95 @@ class TestOperationStatsSplitsLocalFromRouted:
         assert stats["routed_not_found"] == 3
 
 
+class TestPutAndUpdateAreVolumeNotSuccess:
+    """PUT/UPDATE terminals are minted per HOP, so no client-visible rate can be
+    derived from them — the reasoning SUBSCRIBE has always had applied.
+
+    Their published ratios were inverted, not merely noisy. UPDATE read 0.0-0.1%
+    (update_request fires ~1,553x per transaction) while updates propagated
+    fine. PUT computed 148.6% / 147.5% / 134.2% in 6 of 8 buckets, drawn against
+    a hardcoded max of 100, so it rendered pinned flat at the top — a broken
+    measurement displaying as perfect health, which is worse than an obviously
+    wrong number. Fixing properly needs freenet-core#5250.
+    """
+
+    def test_no_put_or_update_rate_is_published(self, srv):
+        t = time.time_ns()
+        for i in range(40):
+            feed(srv, "put_request", t + i, tx_id=f"p-{i}")
+        for i in range(60):  # more successes than requests: the >100% shape
+            feed(srv, "put_success", t + 100 + i, tx_id=f"p-{i % 40}")
+        for i in range(30):
+            feed(srv, "update_request", t + 200 + i, tx_id=f"u-{i}")
+        feed(srv, "update_success", t + 300, tx_id="u-0")
+
+        point = series_of(srv)
+        for gone in ("put_rate", "upd_rate", "put_n", "upd_n"):
+            assert gone not in point, (
+                f"{gone!r} is a per-hop ratio presented as an outcome"
+            )
+
+    def test_the_impossible_put_ratio_is_not_published_anywhere(self, srv):
+        """60 successes over 40 requests is 150%. No published value may be it."""
+        t = time.time_ns()
+        for i in range(40):
+            feed(srv, "put_request", t + i, tx_id=f"p-{i}")
+        for i in range(60):
+            feed(srv, "put_success", t + 100 + i, tx_id=f"p-{i % 40}")
+
+        point = series_of(srv)
+        rates = [v for k, v in point.items() if k.endswith("_rate") and v is not None]
+        assert not any(v > 100 for v in rates), f"a published rate exceeds 100%: {rates}"
+        assert 150.0 not in rates
+
+    def test_volume_is_still_reported_under_hop_names(self, srv):
+        t = time.time_ns()
+        for i in range(40):
+            feed(srv, "put_request", t + i, tx_id=f"p-{i}")
+        for i in range(60):
+            feed(srv, "put_success", t + 100 + i, tx_id=f"p-{i % 40}")
+        for i in range(30):
+            feed(srv, "update_request", t + 200 + i, tx_id=f"u-{i}")
+
+        point = series_of(srv)
+        assert point["put_hops_n"] == 40
+        assert point["put_hops_ok"] == 60
+        assert point["upd_hops_n"] == 30
+        # Every PUT/UPDATE key exposed must carry the hop caveat in its name.
+        for k in point:
+            if k.startswith(("put", "upd")):
+                assert "hops" in k, f"{k!r} does not say it is a per-hop count"
+
+    def test_the_chart_draws_them_on_a_separate_uncapped_axis(self):
+        """A count on a 0-100 axis is how 148.6% rendered as flat healthy."""
+        import os
+        js = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+                          "js", "metrics.js")
+        with open(js, encoding="utf-8") as f:
+            src = f.read()
+        assert "'PUT hops'" in src and "'UPDATE hops'" in src
+        # Assert the DATASETS are bound to the volume axis, not merely that the
+        # axis is declared somewhere. A first version of this pin checked only
+        # `"yVol" in src`, and passed when every dataset was pointed back at the
+        # 0-100 success axis — the exact regression it exists to catch.
+        for label in ("PUT hops", "UPDATE hops"):
+            block = src[src.index(f"label: '{label}'"):]
+            block = block[:block.index("},")]
+            assert "yAxisID: 'yVol'" in block, (
+                f"the {label} dataset is drawn on the success-% axis"
+            )
+        # The volume axis must not be capped. Match the actual property
+        # (`max: <number>`), not the bare word — the block's own comment
+        # explains that there is no max, and a needle its explanation
+        # satisfies would fire on the correct code.
+        import re
+        vol = src[src.index("yVol: {"):]
+        vol = vol[:vol.index("\n                y: {")]
+        assert not re.search(r"^\s*max:\s*\d", vol, re.M), (
+            "capping a count reproduces the original defect"
+        )
+
+
 class TestSubscribeHasNoSuccessRate:
     """issue #15 follow-up: SUBSCRIBE has no client-facing terminal event.
 

--- a/tests/test_metrics_chart_contract.py
+++ b/tests/test_metrics_chart_contract.py
@@ -50,8 +50,9 @@ def test_every_series_key_the_chart_reads_is_emitted(srv):
 
 
 @pytest.mark.parametrize("key", [
-    "get_routed_rate", "get_sub_rate", "put_rate", "upd_rate",
-    "get_routed_n", "get_sub_n", "put_n", "upd_n",
+    "get_routed_rate", "get_sub_rate",
+    "get_routed_n", "get_sub_n",
+    "put_hops_n", "put_hops_ok", "upd_hops_n", "upd_hops_ok",
     # The headline sums these directly; get_routed_ok_n in particular must be
     # published, because reconstructing it from get_routed_rate loses every
     # bucket below METRICS_MIN_SAMPLES.

--- a/ws_server.py
+++ b/ws_server.py
@@ -803,19 +803,40 @@ def get_metrics_timeseries():
 
         series.append({
             "t": b["ts"],
-            "put_rate": rate_or_none(b["put_ok"], put_total),
+            # No put_rate / upd_rate. put_request/put_success and
+            # update_request/update_success are minted per HOP on the response
+            # path, so their ratio weights by route length rather than
+            # measuring what a client saw — the same defect as issue #15, and
+            # the same reason SUBSCRIBE has never had a rate.
+            #
+            # Their ratios were not merely imprecise, they were inverted:
+            # UPDATE read 0.0-0.1% (update_request fires ~1,553 times per
+            # transaction, one produced 10,741) while updates propagated fine,
+            # and PUT computed 148.6% / 147.5% / 134.2% in 6 of 8 buckets
+            # because put_success fires at more points per tx than put_request.
+            # The y-axis is capped at 100, so PUT drew PINNED FLAT AT THE TOP —
+            # a broken measurement rendering as perfect health.
+            #
+            # There is no arithmetic that fixes this; it needs a client-facing
+            # terminal event the core does not emit (freenet-core#5250). Until
+            # then these ship as volume only.
             # Deliberately NOT named get_rate. The old key meant "direct GETs,
             # routed or not"; a consumer still reading it should break loudly
             # rather than silently keep plotting a differently-scoped number.
             "get_routed_rate": rate_or_none(pop("direct_network", "success"), net_total),
             "get_sub_rate": rate_or_none(sub_ok, get_sub_total),
-            "upd_rate": rate_or_none(b["upd_ok"], upd_total),
             # No sub_rate. SUBSCRIBE has no client-facing terminal event, so
             # subscribe_success/_not_found are minted per hop on the response
             # path and their ratio weights by hop count — the same defect that
             # made GET read 0.05% against a real 87% (issue #15). There is no
             # arithmetic that fixes it, so the counts ship without a rate.
-            "put_n": put_total,
+            # PUT/UPDATE volume, named so it cannot be read as an outcome:
+            # these are per-HOP event counts, so they track how much work the
+            # network did, not how much of it succeeded.
+            "put_hops_n": put_total,
+            "put_hops_ok": b["put_ok"],
+            "upd_hops_n": upd_total,
+            "upd_hops_ok": b["upd_ok"],
             "get_routed_n": net_total,
             # EXACT routed success count, not derivable from the rate above.
             # The 24h headline sums raw counts across buckets, and a bucket
@@ -826,7 +847,6 @@ def get_metrics_timeseries():
             # the numerator so no consumer has to invert a rounded rate.
             "get_routed_ok_n": pop("direct_network", "success"),
             "get_sub_n": get_sub_total,
-            "upd_n": upd_total,
             # Why routed GETs failed. not_found and timeout_exhausted imply
             # different problems (findability/placement vs routing/transport),
             # so a single failure rate would average away which one is biting.


### PR DESCRIPTION

## Problem

Both were plotted as "success %" from per-HOP counters, and both were
inverted rather than merely imprecise.

UPDATE read 0.0-0.1%. `update_request` fires on every relay forward:
measured over a 10-minute slice, 1,553 request-events per transaction, one
transaction alone producing 10,741. An operator reads total update failure
while updates are propagating fine.

PUT computed ABOVE 100% - 148.6%, 147.5%, 134.2% in 6 of 8 four-hour
buckets - because `put_success` fires at more points per transaction than
`put_request`. The y-axis was hardcoded `max: 100`, so the line drew PINNED
FLAT AT THE TOP, indistinguishable from a healthy 100%. A broken
measurement rendering as perfect health is worse than one rendering as an
obviously wrong number: nothing invites a second look.

`telemetry_db.py` already documented that these hop-observed terminals
"MUST NOT be aggregated into a success rate", and `get_metrics_timeseries`
did it anyway. The code carried its own warning and ignored it.

## Approach

Do what SUBSCRIBE has always correctly done: ship the counts, publish no
rate. `put_rate`, `upd_rate`, `put_n` and `upd_n` are removed; the volume
ships as `put_hops_n` / `put_hops_ok` / `upd_hops_n` / `upd_hops_ok`, where
every exposed key carries the hop caveat in its name (asserted by a test).

On the chart the two lines move to a separate right-hand "hop events" axis
that is deliberately uncapped, since capping a count is precisely how
148.6% came to look like health. The tooltip returns a count and never
reaches the "%" formatting.

This is the interim honest presentation, not the fix. A real PUT/UPDATE
success rate needs a client-facing terminal event the core does not emit -
filed as freenet-core#5250. Until then the network has no client-visible
success signal for three of its four operations, which is worth knowing
rather than papering over.

## Testing

Feeding 60 put_success against 40 put_request - the >100% shape - asserts
no published rate exceeds 100% and that 150.0 appears nowhere. Separate
tests pin that no put/upd rate key is published at all, that volume
survives under hop-named keys, and that the datasets are bound to the
uncapped volume axis.

That last pin was itself caught being weak mid-review: its first version
asserted only that `yVol` appeared somewhere in the source, and passed when
every dataset was pointed back at the 0-100 axis - the exact regression it
exists to catch. It now reads the dataset block and asserts the binding.
Same trap, twice in one change: a needle that the code's own explanatory
comment satisfies. Both now match the property, not the prose.

Companion to #19. Interim measure; the real fix is freenet/freenet-core#5250.

[AI-assisted - Claude]